### PR TITLE
Feat: Issue#76 POST and GET /user/additional_info api endpoints

### DIFF
--- a/app/api/dao/user_extension.py
+++ b/app/api/dao/user_extension.py
@@ -1,8 +1,9 @@
 from http import HTTPStatus
-# from typing import Dict
-# from sqlalchemy import func
+from flask import json
 from app.database.models.bit_schema.user_extension import UserExtensionModel
 from app import messages
+from app.api.request_api_utils import AUTH_COOKIE
+from app.utils.bitschema_utils import Timezone
 
 
 class UserExtensionDAO:
@@ -10,7 +11,7 @@ class UserExtensionDAO:
     """Data Access Object for Users_Extension functionalities"""
 
     @staticmethod
-    def create_user_extension(data):
+    def create_user_additional_info(data):
         """Creates a user_extension instance for a new registered user.
 
         Arguments:
@@ -21,17 +22,54 @@ class UserExtensionDAO:
                 A dictionary containing "message" which indicates whether or not the user_exension was created successfully and "code" for the HTTP response code.
         """
 
-        user_id = data["user_id"]
-        is_organization_rep = data["is_organization_rep"]
-        timezone = data["timezone"]
+        try:
+            user_id = AUTH_COOKIE["user_id"].value
+        except KeyError:
+            return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN
+        
+        timezone_value = data["timezone"]
+            
+        additional_info_data = {}
+        
+        existing_additional_info = UserExtensionModel.find_by_user_id(user_id)
+        if existing_additional_info:
+            return messages.ADDITIONAL_INFORMATION_OF_USER_ALREADY_EXIST, HTTPStatus.CONFLICT
+        
+        timezone = Timezone(timezone_value).name
+        user_extension = UserExtensionModel(user_id, timezone)
+        
+        try:
+            user_extension.is_organization_rep = data["is_organization_rep"]
+            additional_info_data["phone"] = data["phone"]
+            additional_info_data["mobile"] = data["mobile"]
+            additional_info_data["personal_website"] = data["personal_website"]
+        except KeyError as e:
+            return e, HTTPStatus.BAD_REQUEST
 
-        user_extension = UserExtensionModel(user_id, is_organization_rep, timezone)
+        user_extension.additional_info = additional_info_data
         
         user_extension.save_to_db()
 
-        response = {
-            "message": f"{messages.USER_WAS_CREATED_SUCCESSFULLY}",
-            "code": f"{HTTPStatus.CREATED}",
-        }
+        return messages.ADDITIONAL_INFO_SUCCESSFULLY_CREATED, HTTPStatus.CREATED
 
-        return response
+    @staticmethod
+    def get_user_additional_data_info(user_id):
+        """Retrieves a user's additional information using a specified ID.
+
+        Arguments:
+            user_id: The ID of the user to be searched.
+
+        Returns:
+            The UserModel class of the user whose ID was searched, containing their additional information.
+        """
+
+        result = UserExtensionModel.find_by_user_id(user_id)
+        if result:
+            return {
+                "user_id": result.user_id,
+                "is_organization_rep": result.is_organization_rep,
+                "timezone": result.timezone.value,
+                "phone": result.additional_info["phone"],
+                "mobile": result.additional_info["mobile"],
+                "personal_website": result.additional_info["personal_website"]
+            }

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -6,8 +6,10 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[login_request_body_model.name] = login_request_body_model
     api_namespace.models[login_response_body_model.name] = login_response_body_model
     api_namespace.models[full_user_api_model.name] = full_user_api_model
-    api_namespace.models[update_user_request_body_model.name] = update_user_request_body_model
-
+    api_namespace.models[update_user_details_request_body_model.name] = update_user_details_request_body_model
+    api_namespace.models[get_user_extension_response_model.name] = get_user_extension_response_model
+    api_namespace.models[user_extension_request_body_model.name] = user_extension_request_body_model
+    
 register_user_api_model = Model(
     "User registration model",
     {
@@ -97,8 +99,8 @@ full_user_api_model = Model(
     },
 )
 
-update_user_request_body_model = Model(
-    "Update User request data model",
+update_user_details_request_body_model = Model(
+    "Update User details request data model",
     {
         "name": fields.String(required=False, description="User name"),
         "username": fields.String(required=False, description="User username"),
@@ -125,4 +127,27 @@ update_user_request_body_model = Model(
             required=False, description="User availability to mentor indication"
         ),
     },
+)
+
+get_user_extension_response_model = Model(
+    "Retrieve additional information response data model",
+    {
+        "user_id": fields.Integer(required=True, description="User Id"),
+        "is_organization_rep": fields.Boolean(required=True, description="User represents organization"),
+        "timezone": fields.String(required=True, description="User's timezone"),
+        "phone": fields.String(required=False, description="phone"),
+        "mobile": fields.String(required=False, description="mobile"),
+        "personal_website": fields.String(required=False, description="personal_website"),
+    }
+)
+
+user_extension_request_body_model = Model(
+    "Create or Update user's additional information data model",
+    {
+        "is_organization_rep": fields.Boolean(required=True, description="User represents organization"),
+        "timezone": fields.String(required=True, description="User's timezone"),
+        "phone": fields.String(required=False, description="phone"),
+        "mobile": fields.String(required=False, description="mobile"),
+        "personal_website": fields.String(required=False, description="personal_website"),
+    }
 )

--- a/app/api/request_api_utils.py
+++ b/app/api/request_api_utils.py
@@ -113,7 +113,6 @@ def validate_token(token):
             return messages.TOKEN_IS_INVALID, HTTPStatus.UNAUTHORIZED
         if  datetime.utcnow().timestamp() > AUTH_COOKIE["Authorization"]["expires"]:
             return messages.TOKEN_HAS_EXPIRED, HTTPStatus.UNAUTHORIZED
-        return ()
       
 
 @http_response_namedtuple_converter

--- a/app/api/resources/users.py
+++ b/app/api/resources/users.py
@@ -10,16 +10,25 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from flask_restx import Resource, marshal, Namespace
-from app.api.request_api_utils import post_request, get_request, put_request, http_response_checker, AUTH_COOKIE
 from app import messages
-from app.api.models.user import *
+from app.api.request_api_utils import (
+    post_request, 
+    get_request, 
+    put_request, 
+    http_response_checker, 
+    AUTH_COOKIE, 
+    validate_token)
 from app.api.validations.user import *
-from app.utils.validation_utils import expected_fields_validator
 from app.api.resources.common import auth_header_parser
+from app.api.models.user import *
+from app.api.dao.user_extension import UserExtensionDAO
+from app.utils.validation_utils import expected_fields_validator
+from app.database.models.bit_schema.user_extension import UserExtensionModel
 
 users_ns = Namespace("Users", description="Operations related to users")
 add_models_to_namespace(users_ns)
 
+UserExtensionDAO = UserExtensionDAO()
 
 @users_ns.route("register")
 class UserRegister(Resource):
@@ -57,7 +66,7 @@ class UserRegister(Resource):
 
         The endpoint accepts user input related to Mentorship System API (name, username, password, email,
         terms_and_conditions_checked(true/false), need_mentoring(true/false),
-        available_to_mentor(true/false)) and Bridge In Tech API (is_organization_rep and timezone).
+        available_to_mentor(true/false)).
         A success message is displayed and verification email is sent to the user's email ID.
         """
 
@@ -71,9 +80,7 @@ class UserRegister(Resource):
         if is_not_valid:
             return is_not_valid, HTTPStatus.BAD_REQUEST
             
-        result = post_request("/register", data)
-
-        return http_response_checker(result)
+        return http_response_checker(post_request("/register", data))
 
         
 @users_ns.route("login")
@@ -115,61 +122,48 @@ class LoginUser(Resource):
         if not password:
             return messages.PASSWORD_FIELD_IS_MISSING, HTTPStatus.BAD_REQUEST
 
-        result = post_request("/login", data)
-
-        return http_response_checker(result)
+        return http_response_checker(post_request("/login", data))
         
-
-@users_ns.route("user/personal_details")
-class MyProfilePersonalDetails(Resource):
-    @classmethod
-    @users_ns.doc("get_user")
-    @users_ns.response(HTTPStatus.OK, "Successful request", full_user_api_model)
-    @users_ns.response(
+@users_ns.response(
         HTTPStatus.UNAUTHORIZED,
         f"{messages.TOKEN_HAS_EXPIRED}\n"
         f"{messages.TOKEN_IS_INVALID}\n"
         f"{messages.AUTHORISATION_TOKEN_IS_MISSING}"
-    )
-    @users_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
-    @users_ns.response(HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}")
+)
+@users_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@users_ns.response(HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}")
+@users_ns.route("user/personal_details")
+class MyProfilePersonalDetails(Resource):
+    @classmethod
+    @users_ns.doc("get_user_personal_details")
+    @users_ns.response(HTTPStatus.OK, "Successful request", full_user_api_model)
     @users_ns.expect(auth_header_parser, validate=True)
     def get(cls):
         """
-        Returns details of current user.
+        Returns personal details of current user.
 
-        A user with valid access token can use this endpoint to view his/her own
+        A user with valid access token can use this endpoint to view their own
         user details. The endpoint doesn't take any other input.
         """
         token = request.headers.environ["HTTP_AUTHORIZATION"]
-        
-        result = get_request("/user", token)
-        
-        return http_response_checker(result)
+
+        return http_response_checker(get_request("/user", token))
 
 
     @classmethod
-    @users_ns.doc("update_user_profile")
+    @users_ns.doc("update_user_personal_details")
     @users_ns.response(HTTPStatus.OK, f"{messages.USER_SUCCESSFULLY_UPDATED}")
     @users_ns.response(HTTPStatus.BAD_REQUEST, "Invalid input.")
-    @users_ns.response( 
-         HTTPStatus.UNAUTHORIZED,
-        f"{messages.TOKEN_HAS_EXPIRED}\n"
-        f"{messages.TOKEN_IS_INVALID}\n"
-        f"{messages.AUTHORISATION_TOKEN_IS_MISSING}"
-    )
-    @users_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
-    @users_ns.response(HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}")
-    @users_ns.expect(auth_header_parser, update_user_request_body_model, validate=True,)
+    @users_ns.expect(auth_header_parser, update_user_details_request_body_model, validate=True,)
     def put(cls):
         """
-        Updates user profile
+        Updates user personal details
 
-        A user with valid access token can use this endpoint to edit his/her own
+        A user with valid access token can use this endpoint to edit their own
         user details. The endpoint takes any of the given parameters (name, username,
         bio, location, occupation, organization, slack_username, social_media_links,
         skills, interests, resume_url, photo_url, need_mentoring, available_to_mentor).
-        The response contains a success message.
+        The response contains a success or error message.
         """
 
         data = request.json
@@ -177,7 +171,7 @@ class MyProfilePersonalDetails(Resource):
         if not data:
             return messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT
 
-        is_field_valid = expected_fields_validator(data, update_user_request_body_model)
+        is_field_valid = expected_fields_validator(data, update_user_details_request_body_model)
         if not is_field_valid.get("is_field_valid"):
             return is_field_valid.get("message"), HTTPStatus.BAD_REQUEST
         
@@ -187,8 +181,106 @@ class MyProfilePersonalDetails(Resource):
 
         token = request.headers.environ["HTTP_AUTHORIZATION"]
         
-        result = put_request("/user", token, data)
-        return http_response_checker(result)
+        return http_response_checker(put_request("/user", token, data))
 
     
-  
+@users_ns.response( 
+        HTTPStatus.UNAUTHORIZED,
+    f"{messages.TOKEN_HAS_EXPIRED}\n"
+    f"{messages.TOKEN_IS_INVALID}\n"
+    f"{messages.AUTHORISATION_TOKEN_IS_MISSING}"
+)
+@users_ns.response(
+        HTTPStatus.FORBIDDEN, f"{messages.USER_ID_IS_NOT_RETRIEVED}"
+)
+@users_ns.response(HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}")
+@users_ns.route("user/additional_info")
+class MyProfileAdditionalInfo(Resource):
+    @classmethod
+    @users_ns.doc("get_user_additional_info")
+    @users_ns.response(HTTPStatus.OK, "Successful request", get_user_extension_response_model)
+    @users_ns.response(HTTPStatus.BAD_REQUEST, "Invalid input.")
+    @users_ns.response(HTTPStatus.NOT_FOUND, f"{messages.ADDITIONAL_INFORMATION_DOES_NOT_EXIST}")
+    @users_ns.expect(auth_header_parser, validate=True)
+    def get(cls):
+        """
+        Returns additional information of current user
+
+        A user with valid access token can use this endpoint to view their additional information details. 
+        The endpoint doesn't take any other input. But the user must get their personal details first 
+        before they can send this request for getting the additional information.
+        """
+
+        token = request.headers.environ["HTTP_AUTHORIZATION"]
+
+        is_wrong_token = validate_token(token)
+
+        if not is_wrong_token:
+            try:
+                user_id = AUTH_COOKIE["user_id"].value
+            except KeyError:
+                return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN
+                
+            result = UserExtensionDAO.get_user_additional_data_info(user_id)
+            if not result:
+                return messages.ADDITIONAL_INFORMATION_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
+            return result 
+        return is_wrong_token
+    
+
+    @classmethod
+    @users_ns.doc("create_user_additional_info")
+    @users_ns.doc(
+        responses={
+            HTTPStatus.INTERNAL_SERVER_ERROR: f"{messages.INTERNAL_SERVER_ERROR['message']}"
+        }
+    )
+    @users_ns.response(
+        HTTPStatus.CREATED, f"{messages.ADDITIONAL_INFO_SUCCESSFULLY_CREATED}"
+    )
+    @users_ns.response(
+        HTTPStatus.BAD_REQUEST,
+        f"{messages.USER_ID_IS_NOT_VALID}\n"
+        f"{messages.IS_ORGANIZATION_REP_FIELD_IS_MISSING}\n"
+        f"{messages.TIMEZONE_FIELD_IS_MISSING}"
+        f"{messages.UNEXPECTED_INPUT}"
+    )
+    @users_ns.response(
+        HTTPStatus.FORBIDDEN, f"{messages.USER_ID_IS_NOT_RETRIEVED}"
+    )
+    @users_ns.response(
+        HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}"
+    )
+    @users_ns.expect(auth_header_parser, user_extension_request_body_model, validate=True)
+    def post(cls):
+        """
+        Creates user additional information
+
+        A user with valid access token can use this endpoint to add additional information to their own data. 
+        The endpoint takes any of the given parameters (is_organization_rep (true or false value), timezone 
+        (with value as per Timezine Enum Name) and additional_info (dictionary of phone, mobile and personal_website)).
+        The response contains a success or error message. This request only accessible once user confirm 
+        their additional information have not already exist in the data through sending GET request for 
+        additional information.
+        """
+
+        token = request.headers.environ["HTTP_AUTHORIZATION"]
+        is_wrong_token = validate_token(token)
+        
+        if not is_wrong_token:
+            data = request.json
+            if not data:
+                return messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT
+
+            is_field_valid = expected_fields_validator(data, user_extension_request_body_model)
+            if not is_field_valid.get("is_field_valid"):
+                return is_field_valid.get("message"), HTTPStatus.BAD_REQUEST
+            
+            is_not_valid = validate_update_additional_info_request(data)
+            if is_not_valid:
+                return is_not_valid, HTTPStatus.BAD_REQUEST
+
+            return UserExtensionDAO.create_user_additional_info(data)
+             
+        return is_wrong_token
+    

--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -3,6 +3,7 @@ from app.utils.validation_utils import (
     is_name_valid,
     is_email_valid,
     is_username_valid,
+    is_phone_valid,
     validate_length,
     get_stripped_string,
 )
@@ -241,3 +242,20 @@ def validate_new_password(data):
         return is_valid.get("message")
 
     return {}
+
+def validate_update_additional_info_request(data):
+    if "is_organization_rep" not in data:
+        return messages.IS_ORGANIZATION_REP_FIELD_IS_MISSING
+    if "timezone" not in data:
+        return messages.TIMEZONE_FIELD_IS_MISSING
+
+    phone = data.get("phone", None)
+    mobile = data.get("mobile", None)
+    
+    if phone:
+        if not is_phone_valid(phone):
+            return messages.PHONE_OR_MOBILE_IS_NOT_IN_NUMBER_FORMAT
+    if mobile:
+        if not is_phone_valid(mobile):
+            return messages.PHONE_OR_MOBILE_IS_NOT_IN_NUMBER_FORMAT
+    

--- a/app/database/models/bit_schema/user_extension.py
+++ b/app/database/models/bit_schema/user_extension.py
@@ -31,12 +31,12 @@ class UserExtensionModel(db.Model):
 
     """Initialises UserExtensionModel class."""
     ## required fields
-    def __init__(self, user_id, is_organization_rep, timezone):
+    def __init__(self, user_id, timezone):
         self.user_id = user_id
         self.timezone = timezone
 
         # default value
-        self.is_organization_rep = is_organization_rep
+        self.is_organization_rep = False
         self.additional_info = None
 
     def json(self):

--- a/app/messages.py
+++ b/app/messages.py
@@ -14,6 +14,12 @@ FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {
 PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH = {
     "message": f"The password field has to be at least {PASSWORD_MIN_LENGTH} characters and no more than {PASSWORD_MAX_LENGTH} characters."
 }
+PHONE_OR_MOBILE_IS_NOT_IN_NUMBER_FORMAT = {
+    "message": "Phone and mobile fields must be in number format. It must contain numbers and may contain dash ""-"" or space "" "" characters."
+}
+WEBSITE_URL_IS_INVALID = {
+    "message": "The website url is not in valid format. It must have ""http*"
+}
 
 # Not found
 MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {
@@ -49,6 +55,8 @@ NEW_PASSWORD_FIELD_IS_MISSING = {"message": "New password field is missing."}
 AUTHORISATION_TOKEN_IS_MISSING = {"message": "The authorization token is" " missing!"}
 DESCRIPTION_FIELD_IS_MISSING = {"message": "Description field is missing."}
 COMMENT_FIELD_IS_MISSING = {"message": "Comment field is missing."}
+TIMEZONE_FIELD_IS_MISSING = {"message": "Timezone information is missing."}
+IS_ORGANIZATION_REP_FIELD_IS_MISSING = {"message": "Please indicate whether or not you represent an organization that is registered/going to be registered with BridgeInTech."}
 
 # Admin
 USER_IS_ALREADY_AN_ADMIN = {"message": "User is already an Admin."}
@@ -94,10 +102,20 @@ TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE = {
     "message": "You have not created the comment and therefore cannot " "delete it."
 }
 
-# Update
+# Update/Create
 NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT = {
     "message": "No data for updating" "profile was sent."
 }
+ADDITIONAL_INFORMATION_DOES_NOT_EXIST = {
+    "message": "No additional information found with your data. Please provide them now."
+}
+ADDITIONAL_INFORMATION_OF_USER_ALREADY_EXIST = {
+    "message": "Additional information already exist with your data. You may update it."
+}
+USER_EXTENSION_DATA_HAS_MISSING_FIELD = {
+    "message": "Additional information is missing one of its field."
+}
+
 
 # Relation constraints
 MENTOR_ID_SAME_AS_MENTEE_ID = {
@@ -272,6 +290,7 @@ TASK_COMMENT_WAS_DELETED_SUCCESSFULLY = {
 LIST_TASK_COMMENTS_WITH_SUCCESS = {
     "message": "List task comments from a mentorship relation with success."
 }
+ADDITIONAL_INFO_SUCCESSFULLY_CREATED = {"message": "User additional info successfully created."}
 
 # confimation
 ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed."}
@@ -291,3 +310,6 @@ INTERNAL_SERVER_ERROR = {
 }
 
 UNEXPECTED_INPUT = {"message": "Unexpected input is detected. Please check your input to make sure only approved fields are to be submitted."}
+USER_ID_IS_NOT_RETRIEVED = {
+    "message": "You must view your personal details first before you can proceed."
+}

--- a/app/utils/bitschema_utils.py
+++ b/app/utils/bitschema_utils.py
@@ -102,6 +102,7 @@ class Religion(Enum):
 class PhysicalAbility(Enum):
     WITH_DISABILITY = "With/had limited physical ability (or with/had some type of physical disability/ies)"
     WITHOUT_DISABILITY = "Without/have no limitation to physical ability/ies"
+    OTHER = "Other"
     DECLINED = "Prefer not to say"
     NOT_APPLICABLE = "Not Applicable"
 
@@ -113,6 +114,7 @@ class PhysicalAbility(Enum):
 class MentalAbility(Enum):
     WITH_DISORDER = "With/previously had some type of mental disorders"
     WITHOUT_DISORDER = "Without/have no mental disorders"
+    OTHER = "Other"
     DECLINED = "Prefer not to say"
     NOT_APPLICABLE = "Not Applicable"
 
@@ -127,6 +129,7 @@ class SocioEconomic(Enum):
     LOWER_MIDDLE = "Lower Middle class (e.g. blue collars in skilled trades/Paralegals/Bank tellers/Sales/Clerical-Admin/other support workers)"
     WORKING = "Working class (e.g. craft workers, factory labourers, restaurant/delivery services workers"
     BELOW_POVERTY = "Underclass, working but with wages under poverty line, receiving Social Benefit from Government"
+    OTHER = "Other"
     DECLINED = "Prefer not to say"
     NOT_APPLICABLE = "Not Applicable"
 
@@ -153,9 +156,9 @@ class HighestEducation(Enum):
 @unique
 class YearsOfExperience(Enum):
     UNDER_ONE = "Less than a year"
-    UP_TO_3 = "Up to 3 years"
-    UP_TO_5 = "Up to 5 years"
-    UP_TO_10 = "Up to 10 year"
+    UP_TO_3 = "Between 1 to 3 years"
+    UP_TO_5 = "Between 3 to 5 years"
+    UP_TO_10 = "Between 5 to 10 year"
     OVER_10 = "Over 10 years of experience"
     DECLINED = "Prefer not to say"
     NOT_APPLICABLE = "Not Applicable"

--- a/app/utils/validation_utils.py
+++ b/app/utils/validation_utils.py
@@ -26,6 +26,11 @@ For the "username" field to be valid, it may contain one or more character from:
     - letter "a" to "z" and/or "A" to "Z",
     - number "0" to "9", and/or
     - special character "-".
+
+For the "phone" or "mobile" field to be valid, it must have the following format:
+    - must contain numbers from "0" to "9" 
+    - may contain one or more character from special character "-"
+    - may contain one or more character from whitespace " "
 """
 import re
 from app import messages
@@ -34,7 +39,7 @@ from app import messages
 name_regex = r"(^[a-zA-Z\s\-]+$)"
 email_regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
 username_regex = r"(^[a-zA-Z0-9_]+$)"
-
+phone_regex = r"(^[0-9\s\-\+]+$)"
 
 def is_name_valid(name):
     """Checks if name input is within the acceptable pattern defined in name_regex.
@@ -157,3 +162,15 @@ def expected_fields_validator(user_input, data_model):
     if len(expected_fields) != len(data_model):
         return {"is_field_valid": False, "message": messages.UNEXPECTED_INPUT}
     return {"is_field_valid": True, "message": {}}
+
+def is_phone_valid(phone):
+    """Checks if phone or mobile input is within the acceptable pattern defined in phone_regex.
+    
+    Args:
+        name: string input for phone or mobile.
+    
+    Return:
+        True: if string input for phone or mobile is within the acceptable phone_regex pattern.
+        False: if string input for phone or mobile is not according to phone_regex pattern.
+    """
+    return re.match(phone_regex, phone)

--- a/tests/users/test_api_get_user_details.py
+++ b/tests/users/test_api_get_user_details.py
@@ -1,0 +1,153 @@
+import unittest
+from http import HTTPStatus, cookies
+from unittest.mock import patch, Mock
+import requests
+from requests.exceptions import HTTPError
+from flask import json
+from flask_restx import marshal
+from app import messages
+from tests.base_test_case import BaseTestCase
+from app.api.request_api_utils import post_request, BASE_MS_API_URL, AUTH_COOKIE
+from app.api.resources.users import MyProfilePersonalDetails
+from app.api.models.user import full_user_api_model
+from tests.test_data import user1
+
+
+class TestGetUserDetailsApi(BaseTestCase):
+    
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_api_get_user_details_with_correct_token(self, mock_login, mock_get_user):
+        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
+        # This date need to be adjusted accordingly once the development is near/pass the stated date
+        # to make sure the test still pass.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+      
+        access_token_header = "Bearer this is fake token"
+        expected_user = marshal(user1, full_user_api_model)
+        success_code = HTTPStatus.OK
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_user
+        mock_get_response.status_code = success_code
+
+        mock_get_user.return_value = mock_get_response
+        mock_get_user.raise_for_status = json.dumps(success_code)
+
+        with self.client:
+            get_response = self.client.get(
+                "/user/personal_details",
+                headers={"Authorization": access_token_header},
+                follow_redirects=True,
+            )
+            
+        mock_get_user.assert_called()
+        self.assertEqual(get_response.json, expected_user)
+        self.assertEqual(get_response.status_code, success_code)
+
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_api_get_user_details_with_token_expired(self, mock_login, mock_get_user):
+        # The access_expiry on this test is set to Friday, 26-Jun-20 04:03:58 UTC.
+        # to make sure the test pass for expired token.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1593144238}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+      
+        access_token_header = "Bearer this is fake token"
+
+        error_message = messages.TOKEN_HAS_EXPIRED
+        error_code = HTTPStatus.UNAUTHORIZED
+
+        mock_response = Mock()
+        mock_error = Mock()
+        http_error = requests.exceptions.HTTPError()
+        mock_response.raise_for_status.side_effect = http_error
+        mock_get_user.return_value = mock_response
+        mock_error.json.return_value = error_message
+        mock_error.status_code = error_code
+        mock_get_user.side_effect = requests.exceptions.HTTPError(response=mock_error)
+
+        with self.client:
+            get_response = self.client.get(
+                "/user/personal_details",
+                headers={"Authorization": access_token_header},
+                follow_redirects=True,
+            )
+            
+        mock_get_user.assert_not_called()
+        self.assertEqual(get_response.json, error_message)
+        self.assertEqual(get_response.status_code, error_code)
+
+
+    @patch("requests.get")
+    def test_api_get_user_details_with_internal_server_error(self, mock_get_user):
+
+        access_token_header = "Bearer this is fake token"
+        error_message = messages.INTERNAL_SERVER_ERROR
+        error_code = HTTPStatus.INTERNAL_SERVER_ERROR
+        
+        mock_response = Mock()
+        mock_error = Mock()
+        http_error = requests.exceptions.HTTPError()
+        mock_response.raise_for_status.side_effect = http_error
+        mock_get_user.return_value = mock_response
+        mock_error.json.return_value = error_message
+        mock_error.status_code = error_code
+        mock_get_user.side_effect = requests.exceptions.HTTPError(response=mock_error)
+        
+        with self.client:
+            get_response = self.client.get(
+                "/user/personal_details",
+                headers={"Authorization": access_token_header},
+                follow_redirects=True,
+            )
+            
+        mock_get_user.assert_called()
+        self.assertEqual(get_response.json, error_message)
+        self.assertEqual(get_response.status_code, error_code)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+   

--- a/tests/users/test_api_update_user_details.py
+++ b/tests/users/test_api_update_user_details.py
@@ -9,16 +9,16 @@ from app import messages
 from tests.base_test_case import BaseTestCase
 from app.api.request_api_utils import post_request, BASE_MS_API_URL, AUTH_COOKIE
 from app.api.resources.users import MyProfilePersonalDetails
-from app.api.models.user import update_user_request_body_model
+from app.api.models.user import update_user_details_request_body_model
 from tests.test_data import user1
 
 
 
-class TestUpdateUserApi(BaseTestCase):
+class TestUpdateUserDetailsApi(BaseTestCase):
     
     @patch("requests.post")
     def setUp(self, mock_login):
-        super(TestUpdateUserApi, self).setUp()
+        super(TestUpdateUserDetailsApi, self).setUp()
 
         success_login_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
         success_login_code = HTTPStatus.OK
@@ -59,11 +59,10 @@ class TestUpdateUserApi(BaseTestCase):
             "need_mentoring": True,
             "available_to_mentor": True
         }
-        
-
+    
 
     @patch("requests.put")
-    def test_api_update_user_with_correct_payload(self, mock_update_user):
+    def test_api_update_user_details_with_correct_payload(self, mock_update_user):
         expected_put_message = messages.USER_SUCCESSFULLY_UPDATED
         expected_put_code = HTTPStatus.OK
 
@@ -89,7 +88,7 @@ class TestUpdateUserApi(BaseTestCase):
 
 
     @patch("requests.put")
-    def test_api_get_user_with_new_username_invalid(self, mock_update_user):
+    def test_api_update_user_details_with_new_username_invalid(self, mock_update_user):
         user_invalid_details = {
             "name": "test update",
             "username": "testupdate?",
@@ -134,7 +133,7 @@ class TestUpdateUserApi(BaseTestCase):
 
 
     @patch("requests.put")
-    def test_api_get_user_with_internal_server_error(self, mock_update_user):
+    def test_api_update_user_details_with_internal_server_error(self, mock_update_user):
 
         error_message = messages.INTERNAL_SERVER_ERROR
         error_code = HTTPStatus.INTERNAL_SERVER_ERROR

--- a/tests/users/test_get_user_additional_info.py
+++ b/tests/users/test_get_user_additional_info.py
@@ -13,7 +13,7 @@ from app.api.models.user import full_user_api_model
 from tests.test_data import user1
 
 
-class TestGetUserApi(BaseTestCase):
+class TestGetUserAdditionalInfoApi(BaseTestCase):
     
     @patch("requests.get")
     @patch("requests.post")


### PR DESCRIPTION
### Description
Add POST and GET user/additional_info endpoints to create and get additional information of a user.

Fixes #76 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Steps to test functionalities:
**For GET**
* run the app and go to swagger ui 
* login as existing user and get the access_token
* go to GET /user/personal_details and get user details by providing token (this is a step that MUST be done before user can access their additional information page) since with this `user_id` can be reetrieved and saved as cookie.
* go to GET /user/additional_info and provide the data.
* if user is new and has not yet added their additional information, it should return 404 Not Found.
<img width="759" alt="Screen Shot 2020-07-13 at 1 31 54 am" src="https://user-images.githubusercontent.com/29667122/87324039-e5c41d00-c572-11ea-9f75-291f47ed61e8.png">

* go to POST /user/additional_info to create additional information. Provide token and data in the relevant fields.
    **NOTE**
    - timezone value must be a string enum **value** of Timezone enum from bitschema_utils.py
    - phone and mobile must follow the phone_regex pattern under app/utils/validation_utils.py
    - no validation is currently placed for personal_website (icebox: can be a nice-to-have feature) 
    if the response is successful, you should see the following
![Screen Shot 2020-07-14 at 12 38 34 am](https://user-images.githubusercontent.com/29667122/87324275-38053e00-c573-11ea-91b6-647e6deff01c.png)

* To confirm, go to GET /user//additional_information. Provide token in the specified area. The following is an example of successful request:
<img width="762" alt="Screen Shot 2020-07-14 at 1 16 37 am" src="https://user-images.githubusercontent.com/29667122/87324574-a0ecb600-c573-11ea-9499-6f67402aa1bd.png">



### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
