### PR TITLE
docs: Add wiki documentation links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,23 @@ Please read our [Contributing Guidelines](.github/CONTRIBUTING.md), [Code of Con
 ## Setup
 To start contributing to the project, setup the backend environment on your local machine by following the instructions on the [BIT Development Environment Setup Instruction]( https://github.com/anitab-org/bridge-in-tech-backend/wiki/BIT-development-environment-setup) wiki page.
 
+If you prefer to test the latest approved and merged version of the project on the remote server, you can use the [BridgeInTech Heroku Swagger UI server](https://bridgeintech-bit-heroku-psql.herokuapp.com) that already connected to the modified version of Mentorship System heroku backend server made specifically for BridgeInTech development.
 
 ## Branches
 
 This repository has the following branches:
 - **master**: This branch contains the deployment of the backend.
 - **develop**: This contains the latest code. All the contributing PRs must be sent to this branch.
+
+## Project Documentation
+
+This project has live documents that contain information on:
+- Planning - [BridgeInTech Proposal Review](https://docs.google.com/document/d/1uCDCWs8Xyo-3EaUnrLOs48mefXJIN235b1aAswA-s-Y/edit) 
+- [Technical Discussion](https://docs.google.com/document/d/1Fi_dvc1f-J0uuTzzzU7pwZV8hAI9iTX5LlI_THcg_ks/edit#heading=h.gfxf99xhgujm) and Decision made throughout the development
+- [Meeting Minutes](https://docs.google.com/document/d/1QRHzy0IWgAE5bjkwI_Lp67Dv50aywGuUmzmWewQ1rpY/edit?usp=sharing)
+
+For a more complete information on BridgeInTech project, please go to [BridgeInTech Backend Wiki page](https://github.com/anitab-org/bridge-in-tech-backend/wiki).
+
 
 ## Contact
 


### PR DESCRIPTION
### Description
This PR adds BIT Wiki documentations links to README.md file

Fixes #90 

### Type of Change:
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (add wiki doc links to readme file)


### How Has This Been Tested?
View the README.md page on fork repository and confirm its content is as expected.

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes