### PR TITLE
Feat: GET /users/{user_id} api endpoints and tests

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -11,6 +11,7 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[user_extension_request_body_model.name] = user_extension_request_body_model
     api_namespace.models[get_user_personal_background_response_model.name] = get_user_personal_background_response_model
     api_namespace.models[user_personal_background_request_body_model.name] = user_personal_background_request_body_model
+    api_namespace.models[public_user_personal_details_response_model.name] = public_user_personal_details_response_model
 
 register_user_api_model = Model(
     "User registration model",
@@ -204,4 +205,34 @@ user_personal_background_request_body_model = Model(
         "highest_education_other": fields.String(required=False, description="highest_education_other"),
         "is_public": fields.Boolean(required=True, description="is_public"),
     }
+)
+
+public_user_personal_details_response_model = Model(
+    "User personal details list model",
+    {
+        "id": fields.Integer(
+            readOnly=True, description="The unique identifier of a user"
+        ),
+        "username": fields.String(required=True, description="User username"),
+        "name": fields.String(required=True, description="User name"),
+        "slack_username": fields.String(
+            required=True, description="User Slack username"
+        ),
+        "bio": fields.String(required=True, description="User bio"),
+        "location": fields.String(required=True, description="User location"),
+        "occupation": fields.String(required=True, description="User occupation"),
+        "current_organization": fields.String(required=True, description="User current_organization"),
+        "interests": fields.String(required=True, description="User interests"),
+        "skills": fields.String(required=True, description="User skills"),
+        "need_mentoring": fields.Boolean(
+            required=True, description="User need to be mentored indication"
+        ),
+        "available_to_mentor": fields.Boolean(
+            required=True, description="User availability to mentor indication"
+        ),
+        "is_available": fields.Boolean(
+            required=True,
+            description="User availability to mentor or to be mentored indication",
+        ),
+    },
 )

--- a/app/api/request_api_utils.py
+++ b/app/api/request_api_utils.py
@@ -10,6 +10,7 @@ from app.utils.decorator_utils import http_response_namedtuple_converter
 BASE_MS_API_URL = "http://127.0.0.1:4000"
 AUTH_COOKIE = cookies.SimpleCookie()
 
+
 def post_request(request_string, data):
     request_url = f"{BASE_MS_API_URL}{request_string}" 
     try:

--- a/app/api/request_api_utils.py
+++ b/app/api/request_api_utils.py
@@ -43,7 +43,24 @@ def post_request(request_string, data):
         return response_message, response_code
 
 
-def get_request(request_string, token):
+def get_headers(request_string, params):
+    if request_string == "/user":
+        return {"Authorization": AUTH_COOKIE["Authorization"].value, "Accept": "application/json"}
+    if request_string == "/users/verified":
+        return {
+            "Authorization": AUTH_COOKIE["Authorization"].value, 
+            "search": params["search"],
+            "page": str(params["page"]),
+            "per_page": str(params["per_page"]),
+            "Accept": "application/json"
+        }
+    return {
+        "Authorization": AUTH_COOKIE["Authorization"].value,
+        "Accept": "application/json"
+    }
+
+
+def get_request(request_string, token, params):
     request_url = f"{BASE_MS_API_URL}{request_string}" 
     is_wrong_token = validate_token(token)
 
@@ -51,7 +68,7 @@ def get_request(request_string, token):
         try: 
             response = requests.get(
                 request_url,
-                headers={"Authorization": AUTH_COOKIE["Authorization"].value, "Accept": "application/json"}, 
+                headers=get_headers(request_string, params)
             )
             response.raise_for_status()
             response_message = response.json()

--- a/app/api/resources/users.py
+++ b/app/api/resources/users.py
@@ -13,7 +13,7 @@ from flask_restx import Resource, marshal, Namespace
 from app import messages
 from app.api.request_api_utils import (
     post_request, 
-    get_request, 
+    get_request,
     put_request, 
     http_response_checker, 
     AUTH_COOKIE, 
@@ -25,6 +25,7 @@ from app.api.dao.user_extension import UserExtensionDAO
 from app.api.dao.personal_background import PersonalBackgroundDAO
 from app.utils.validation_utils import expected_fields_validator
 from app.database.models.bit_schema.user_extension import UserExtensionModel
+from app.utils.ms_constants import DEFAULT_PAGE, DEFAULT_USERS_PER_PAGE
 
 users_ns = Namespace("Users", description="Operations related to users")
 add_models_to_namespace(users_ns)
@@ -148,7 +149,7 @@ class MyProfilePersonalDetails(Resource):
         """
         token = request.headers.environ["HTTP_AUTHORIZATION"]
 
-        return http_response_checker(get_request("/user", token))
+        return http_response_checker(get_request("/user", token, params=None))
 
 
     @classmethod
@@ -386,3 +387,44 @@ class MyProfilePersonalBackground(Resource):
              
         return is_wrong_token
     
+
+@users_ns.route("users")
+class UsersList(Resource):
+    @classmethod
+    @users_ns.doc("list_users", params={"search": "Search query", "page": "specify page of users", "per_page": "specify number of users per page"})
+    @users_ns.response(
+        HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}"
+    )
+    @users_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+    @users_ns.response( 
+    HTTPStatus.UNAUTHORIZED,
+        f"{messages.TOKEN_HAS_EXPIRED}\n"
+        f"{messages.TOKEN_IS_INVALID}\n"
+        f"{messages.AUTHORISATION_TOKEN_IS_MISSING}"
+    )
+    @users_ns.response(HTTPStatus.OK, "Successful request", public_user_personal_details_response_model)
+    @users_ns.expect(auth_header_parser)
+    def get(cls):
+        """
+        Returns list of all verified users whose names contain the given query.
+
+        A user with valid access token can view the list of verified users. The endpoint
+        doesn't take any other input. A JSON array having an object for each user is
+        returned. The array contains id, username, name, slack_username, bio,
+        location, occupation, current_organization, interests, skills, need_mentoring,
+        available_to_mentor. The current user's details are not returned.
+        """
+
+        token = request.headers.environ["HTTP_AUTHORIZATION"]
+        search = request.args.get("search", "")
+        page = request.args.get("page", default=DEFAULT_PAGE, type=int)
+        per_page = request.args.get("per_page", default=DEFAULT_USERS_PER_PAGE, type=int)
+        
+        params = {
+            "search": search,
+            "page": page,
+            "per_page": per_page
+        }
+        
+        return http_response_checker(get_request("/users/verified", token, params))
+        

--- a/app/utils/ms_constants.py
+++ b/app/utils/ms_constants.py
@@ -1,0 +1,8 @@
+# This file keeps all Constants from Mentorship System backend
+# that does not have relevant files on BridgeInTech
+
+
+# from UserDAO constants
+DEFAULT_PAGE = 1
+DEFAULT_USERS_PER_PAGE = 10
+    

--- a/tests/users/test_api_get_other_user_details.py
+++ b/tests/users/test_api_get_other_user_details.py
@@ -1,0 +1,135 @@
+import unittest
+from http import HTTPStatus, cookies
+from unittest.mock import patch, Mock
+import requests
+from requests.exceptions import HTTPError
+from flask import json
+from flask_restx import marshal
+from app import messages
+from tests.base_test_case import BaseTestCase
+from app.api.request_api_utils import post_request, get_request, BASE_MS_API_URL, AUTH_COOKIE
+from app.api.models.user import full_user_api_model, get_user_extension_response_model
+from tests.test_data import user1, user2, user3
+from app.database.models.ms_schema.user import UserModel
+from app.api.models.user import public_user_personal_details_response_model
+
+
+class TestGetOtherUserPersonalDetailsApi(BaseTestCase):
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_api_other_user_personal_details_with_correct_token(self, mock_login, mock_get_users):
+        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
+        # This date need to be adjusted accordingly once the development is near/pass the stated date
+        # to make sure the test still pass.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+      
+        expected_response = {
+            "id": 2,
+            "username": "usertest",
+            "name": "User test",
+            "slack_username": "Just any slack name",
+            "bio": "Just any bio" ,
+            "location": "Just any location",
+            "occupation": "Just any occupation",
+            "current_organization": "Just any organization",
+            "interests": "Just any interests",
+            "skills": "Just any skills",
+            "need_mentoring":True,
+            "available_to_mentor": True,
+            "is_available": True
+        }
+        success_code = HTTPStatus.OK
+
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_response
+        mock_get_response.status_code = success_code
+
+        mock_get_users.return_value = mock_get_response
+        mock_get_users.raise_for_status = json.dumps(success_code)
+
+        with self.client:
+            get_response = self.client.get(
+                "/users/2",
+                headers={
+                    "Authorization": AUTH_COOKIE["Authorization"].value,
+                    "Accept": "application/json"
+                }, 
+                follow_redirects=True,
+            )
+
+        mock_get_users.assert_called()
+        self.assertEqual(get_response.json, expected_response)
+        self.assertEqual(get_response.status_code, success_code)
+
+    
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_api_other_user_personal_details_with_token_expired(self, mock_login, mock_get_users):
+        # The access_expiry on this test is set to Friday, 26-Jun-20 04:03:58 UTC.
+        # to make sure the test pass for expired token.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1593144238}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+      
+        error_message = messages.TOKEN_HAS_EXPIRED
+        error_code = HTTPStatus.UNAUTHORIZED
+
+        mock_response = Mock()
+        mock_error = Mock()
+        http_error = requests.exceptions.HTTPError()
+        mock_response.raise_for_status.side_effect = http_error
+        mock_get_users.return_value = mock_response
+        mock_error.json.return_value = error_message
+        mock_error.status_code = error_code
+        mock_get_users.side_effect = requests.exceptions.HTTPError(response=mock_error)
+
+        with self.client:
+            get_response = self.client.get(
+                "/users",
+                headers={
+                    "Authorization": AUTH_COOKIE["Authorization"].value,
+                    "Accept": "application/json"
+                }, 
+                follow_redirects=True,
+            )
+        mock_get_users.assert_not_called()
+        self.assertEqual(get_response.json, error_message)
+        self.assertEqual(get_response.status_code, error_code)

--- a/tests/users/test_api_get_users_personal_details.py
+++ b/tests/users/test_api_get_users_personal_details.py
@@ -7,16 +7,17 @@ from flask import json
 from flask_restx import marshal
 from app import messages
 from tests.base_test_case import BaseTestCase
-from app.api.request_api_utils import post_request, BASE_MS_API_URL, AUTH_COOKIE
-from app.api.resources.users import MyProfilePersonalDetails
-from app.api.models.user import full_user_api_model
-from tests.test_data import user1
+from app.api.request_api_utils import post_request, get_request, BASE_MS_API_URL, AUTH_COOKIE
+from app.api.models.user import full_user_api_model, get_user_extension_response_model
+from tests.test_data import user1, user2, user3
+from app.database.models.ms_schema.user import UserModel
+from app.api.models.user import public_user_personal_details_response_model
 
 
-class TestGetUserDetailsApi(BaseTestCase):
+class TestGetUsersListPersonalDetailsApi(BaseTestCase):
     @patch("requests.get")
     @patch("requests.post")
-    def test_api_get_user_details_with_correct_token(self, mock_login, mock_get_user):
+    def test_api_list_users_personal_details_with_correct_token(self, mock_login, mock_get_users):
         # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
         # This date need to be adjusted accordingly once the development is near/pass the stated date
         # to make sure the test still pass.
@@ -42,31 +43,40 @@ class TestGetUserDetailsApi(BaseTestCase):
                 content_type="application/json",
             )
       
-        expected_user = marshal(user1, full_user_api_model)
+        expected_list = [
+            marshal(user2, public_user_personal_details_response_model),
+            marshal(user3, public_user_personal_details_response_model)
+        ]
         success_code = HTTPStatus.OK
 
         mock_get_response = Mock()
-        mock_get_response.json.return_value = expected_user
+        mock_get_response.json.return_value = expected_list
         mock_get_response.status_code = success_code
 
-        mock_get_user.return_value = mock_get_response
-        mock_get_user.raise_for_status = json.dumps(success_code)
+        mock_get_users.return_value = mock_get_response
+        mock_get_users.raise_for_status = json.dumps(success_code)
 
         with self.client:
             get_response = self.client.get(
-                "/user/personal_details",
-                headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+                "/users",
+                headers={
+                    "Authorization": AUTH_COOKIE["Authorization"].value,
+                    "search": "",
+                    "page": None,
+                    "per_page": None,
+                    "Accept": "application/json"
+                }, 
                 follow_redirects=True,
             )
-            
-        mock_get_user.assert_called()
-        self.assertEqual(get_response.json, expected_user)
+
+        mock_get_users.assert_called()
+        self.assertEqual(get_response.json, expected_list)
         self.assertEqual(get_response.status_code, success_code)
 
-
+    
     @patch("requests.get")
     @patch("requests.post")
-    def test_api_get_user_details_with_token_expired(self, mock_login, mock_get_user):
+    def test_api_list_users_personal_details_with_token_expired(self, mock_login, mock_get_users):
         # The access_expiry on this test is set to Friday, 26-Jun-20 04:03:58 UTC.
         # to make sure the test pass for expired token.
         success_message = {"access_token": "this is fake token", "access_expiry": 1593144238}
@@ -98,50 +108,24 @@ class TestGetUserDetailsApi(BaseTestCase):
         mock_error = Mock()
         http_error = requests.exceptions.HTTPError()
         mock_response.raise_for_status.side_effect = http_error
-        mock_get_user.return_value = mock_response
+        mock_get_users.return_value = mock_response
         mock_error.json.return_value = error_message
         mock_error.status_code = error_code
-        mock_get_user.side_effect = requests.exceptions.HTTPError(response=mock_error)
+        mock_get_users.side_effect = requests.exceptions.HTTPError(response=mock_error)
 
         with self.client:
             get_response = self.client.get(
-                "/user/personal_details",
-                headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+                "/users",
+                headers={
+                    "Authorization": AUTH_COOKIE["Authorization"].value,
+                    "search": "",
+                    "page": None,
+                    "per_page": None,
+                    "Accept": "application/json"
+                }, 
                 follow_redirects=True,
             )
-            
-        mock_get_user.assert_not_called()
+        
+        mock_get_users.assert_not_called()
         self.assertEqual(get_response.json, error_message)
         self.assertEqual(get_response.status_code, error_code)
-
-
-    @patch("requests.get")
-    def test_api_get_user_details_with_internal_server_error(self, mock_get_user):
-        error_message = messages.INTERNAL_SERVER_ERROR
-        error_code = HTTPStatus.INTERNAL_SERVER_ERROR
-        
-        mock_response = Mock()
-        mock_error = Mock()
-        http_error = requests.exceptions.HTTPError()
-        mock_response.raise_for_status.side_effect = http_error
-        mock_get_user.return_value = mock_response
-        mock_error.json.return_value = error_message
-        mock_error.status_code = error_code
-        mock_get_user.side_effect = requests.exceptions.HTTPError(response=mock_error)
-        
-        with self.client:
-            get_response = self.client.get(
-                "/user/personal_details",
-                headers={"Authorization": AUTH_COOKIE["Authorization"].value},
-                follow_redirects=True,
-            )
-            
-        mock_get_user.assert_called()
-        self.assertEqual(get_response.json, error_message)
-        self.assertEqual(get_response.status_code, error_code)
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-   


### PR DESCRIPTION
### Description
Allow user to get other membre's personal details

Fixes #98 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
- Make sure you have created 2 users (user a and b) who already verified their email address
- Login as user a
- send GET /userrs/{user_id} request by providing the user b id number
- for successful response (200) you will see below
<img width="647" alt="Screen Shot 2020-07-28 at 11 27 55 pm" src="https://user-images.githubusercontent.com/29667122/88671717-fc00da00-d129-11ea-8b01-2341aa3fe922.png">


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes