### PR TITLE
Feat: refactor Create Update user additional info to one api endpoint

### DIFF
--- a/app/api/dao/personal_background.py
+++ b/app/api/dao/personal_background.py
@@ -12,62 +12,6 @@ class PersonalBackgroundDAO:
     """Data Access Object for Personal_Background functionalities"""
 
     @staticmethod
-    def create_user_personal_background(data):
-        """Creates a personal_background instance for a new registered user.
-
-        Arguments:
-            data: A list containing user's id, and user's background details (gender, 
-            age, ethnicity, sexual_orientation, religion, physical_ability, mental_ability, 
-            socio_economic, highest_education, years_of_experience, others) as well as 
-            whether or not user agrees to make their personal background information
-            public to other members of BridgeInTech.
-    
-        Returns:
-                A dictionary containing "message" which indicates whether or not the user_exension 
-                was created successfully and "code" for the HTTP response code.
-        """
-
-        user_id = int(AUTH_COOKIE["user_id"].value)
-        if user_id == 0:    
-            return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN
-        existing_personal_background = PersonalBackgroundModel.find_by_user_id(user_id)
-        if existing_personal_background:
-            return messages.PERSONAL_BACKGROUND_OF_USER_ALREADY_EXIST, HTTPStatus.CONFLICT
-        
-        try:
-            personal_background = PersonalBackgroundModel(
-                user_id=user_id,
-                gender=Gender(data["gender"]).name,
-                age=Age(data["age"]).name,
-                ethnicity=Ethnicity(data["ethnicity"]).name,
-                sexual_orientation=SexualOrientation(data["sexual_orientation"]).name,
-                religion=Religion(data["religion"]).name,
-                physical_ability=PhysicalAbility(data["physical_ability"]).name,
-                mental_ability=MentalAbility(data["mental_ability"]).name,
-                socio_economic=SocioEconomic(data["socio_economic"]).name,
-                highest_education=HighestEducation(data["highest_education"]).name,
-                years_of_experience=YearsOfExperience(data["years_of_experience"]).name,
-            )  
-            personal_background.others = {
-                "gender_other": data["gender_other"],
-                "ethnicity_other": data["ethnicity_other"],
-                "sexual_orientation_other": data["sexual_orientation_other"],
-                "religion_other": data["religion_other"],
-                "physical_ability_other": data["physical_ability_other"],
-                "mental_ability_other": data["mental_ability_other"],
-                "socio_economic_other": data["socio_economic_other"],
-                "highest_education_other": data["highest_education_other"],
-            } 
-            personal_background.is_public = data["is_public"]    
-        except KeyError as e:
-            return e, HTTPStatus.BAD_REQUEST
-
-        personal_background.save_to_db()
-
-        return messages.PERSONAL_BACKGROUND_SUCCESSFULLY_CREATED, HTTPStatus.CREATED
-
-    
-    @staticmethod
     def get_user_personal_background_info(user_id):
         """Retrieves a user's perrsonal background information using a specified ID.
 

--- a/app/api/dao/user_extension.py
+++ b/app/api/dao/user_extension.py
@@ -11,49 +11,6 @@ class UserExtensionDAO:
     """Data Access Object for Users_Extension functionalities"""
 
     @staticmethod
-    def create_user_additional_info(data):
-        """Creates a user_extension instance for a new registered user.
-
-        Arguments:
-            data: A list containing user's id, boolean value of whether or not
-            the user is representing an organization, as well as their timezone
-    
-        Returns:
-                A dictionary containing "message" which indicates whether or not 
-                the user_exension was created successfully and "code" for the HTTP response code.
-        """
-
-        try:
-            user_id = int(AUTH_COOKIE["user_id"].value)
-        except ValueError:
-            return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN    
-        
-        timezone_value = data["timezone"]
-            
-        additional_info_data = {}
-        
-        existing_additional_info = UserExtensionModel.find_by_user_id(user_id)
-        if existing_additional_info:
-            return messages.ADDITIONAL_INFORMATION_OF_USER_ALREADY_EXIST, HTTPStatus.CONFLICT
-        
-        timezone = Timezone(timezone_value).name
-        user_extension = UserExtensionModel(user_id, timezone)
-        
-        try:
-            user_extension.is_organization_rep = data["is_organization_rep"]
-            additional_info_data["phone"] = data["phone"]
-            additional_info_data["mobile"] = data["mobile"]
-            additional_info_data["personal_website"] = data["personal_website"]
-        except KeyError as e:
-            return e, HTTPStatus.BAD_REQUEST
-
-        user_extension.additional_info = additional_info_data
-        
-        user_extension.save_to_db()
-
-        return messages.ADDITIONAL_INFO_SUCCESSFULLY_CREATED, HTTPStatus.CREATED
-
-    @staticmethod
     def get_user_additional_data_info(user_id):
         """Retrieves a user's additional information using a specified ID.
 
@@ -79,11 +36,9 @@ class UserExtensionDAO:
     @staticmethod
     def update_user_additional_info(data):
         """Updates a user_extension instance.
-
         Arguments:
-            data: A list containing user's id, boolean value of whether or not
-            the user is representing an organization, as well as their timezone
-    
+        data: A list containing user's id, boolean value of whether or not
+        the user is representing an organization, as well as their timezone
         Returns:
                 A dictionary containing "message" which indicates whether or not 
                 the user_exension was updated successfully and "code" for the HTTP response code.
@@ -95,22 +50,26 @@ class UserExtensionDAO:
             return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN    
 
         timezone_value = data["timezone"]
-        timezone = Timezone(timezone_value).name
-        additional_info_data = {}
-        
-        existing_additional_info = UserExtensionModel.find_by_user_id(user_id)
-        if not existing_additional_info:
-            return messages.ADDITIONAL_INFORMATION_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
-        try:
-            existing_additional_info.is_organization_rep = data["is_organization_rep"]
-            existing_additional_info.timezone = timezone
-            additional_info_data["phone"] = data["phone"]
-            additional_info_data["mobile"] = data["mobile"]
-            additional_info_data["personal_website"] = data["personal_website"]
-        except KeyError as e:
-            return e, HTTPStatus.BAD_REQUEST
+        timezone = Timezone(timezone_value).name   
 
-        existing_additional_info.additional_info = additional_info_data
-        existing_additional_info.save_to_db()
+        user_additional_info = UserExtensionModel.find_by_user_id(user_id)
+        if not user_additional_info:
+            user_additional_info = UserExtensionModel(user_id, timezone)
+            return update(user_additional_info, data, timezone, messages.ADDITIONAL_INFO_SUCCESSFULLY_CREATED, HTTPStatus.CREATED)    
+        return update(user_additional_info, data, timezone, messages.ADDITIONAL_INFO_SUCCESSFULLY_UPDATED, HTTPStatus.OK)     
+    
+def update(user, data, timezone, success_message, status_code):
+    additional_info_data = {}
+    try:
+        additional_info_data["phone"] = data["phone"]
+        additional_info_data["mobile"] = data["mobile"]
+        additional_info_data["personal_website"] = data["personal_website"]
+        user.is_organization_rep = data["is_organization_rep"]
+    except KeyError as e:
+        return e, HTTPStatus.BAD_REQUEST
 
-        return messages.ADDITIONAL_INFO_SUCCESSFULLY_UPDATED, HTTPStatus.OK
+    user.timezone = timezone
+    user.additional_info = additional_info_data
+    user.save_to_db()
+
+    return success_message, status_code 

--- a/tests/users/test_api_update_user_additional_info.py
+++ b/tests/users/test_api_update_user_additional_info.py
@@ -115,38 +115,6 @@ class TestUpdateUserAdditionalInfoApi(BaseTestCase):
         self.assertEqual(response.json, success_message)
         self.assertEqual(response.status_code, success_code)
 
-    
-    @patch("requests.put")
-    def test_api_dao_update_user_additional_info_not_exist(self, mock_update_additional_info):
-        error_message = messages.ADDITIONAL_INFORMATION_DOES_NOT_EXIST
-        error_code = HTTPStatus.NOT_FOUND
-
-        mock_response = Mock()
-        http_error = requests.exceptions.HTTPError()
-        mock_response.raise_for_status.side_effect = http_error
-        mock_update_additional_info.return_value = mock_response
-
-        mock_error = Mock()
-        mock_error.json.return_value = error_message
-        mock_error.status_code = error_code
-        mock_update_additional_info.side_effect = requests.exceptions.HTTPError(response=mock_error)
-
-        with self.client:
-            response = self.client.put(
-                "/user/additional_info",
-                headers={"Authorization": AUTH_COOKIE["Authorization"].value},
-                data=json.dumps(
-                    dict(self.correct_payload_update_additional_info)
-                ),
-                follow_redirects=True,
-                content_type="application/json",
-            )
-
-        test_user_additional_info_data = UserExtensionModel.query.filter_by(user_id=self.test_user_data.id).first()
-        self.assertEqual(test_user_additional_info_data, None)
-        self.assertEqual(response.json, error_message)
-        self.assertEqual(response.status_code, error_code)
-
 
     @patch("requests.put")
     def test_api_dao_update_additional_info_with_invalid_timezone(self, mock_update_additional_info):


### PR DESCRIPTION
### Description
Refactor POST and PUT /user/additional_info to one api endpoint

Fixes #100 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
- login as user who has no additional info record
- send GET /user/personal_details request to get user id
- send PUT /user/additional_info to create additional info data. See success response 201 Created if additional info instance is successfully created.
<img width="845" alt="Screen Shot 2020-08-03 at 7 33 18 pm" src="https://user-images.githubusercontent.com/29667122/89169938-4cf94e00-d5c2-11ea-8d06-8ae80f30cff9.png">

- Now update the details and resend PUT /user/additional_info. On success update, see response 200 OK.
<img width="846" alt="Screen Shot 2020-08-03 at 7 34 33 pm" src="https://user-images.githubusercontent.com/29667122/89170114-8a5ddb80-d5c2-11ea-89ee-17a9169014dc.png">


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
