### PR TITLE
Feat: PUT and GET organization and tests

### DIFF
--- a/app/api/bit_extension.py
+++ b/app/api/bit_extension.py
@@ -15,5 +15,7 @@ api.namespaces.clear()
 
 # Adding namespaces
 from app.api.resources.users import users_ns as user_namespace
-
 api.add_namespace(user_namespace, path="/")
+
+from app.api.resources.organizations import organizations_ns as organization_namespace
+api.add_namespace(organization_namespace, path="/")

--- a/app/api/dao/organization.py
+++ b/app/api/dao/organization.py
@@ -1,0 +1,103 @@
+import ast
+from http import HTTPStatus
+from flask import json
+from app.database.models.bit_schema.organization import OrganizationModel
+from app.database.models.bit_schema.user_extension import UserExtensionModel
+from app import messages
+from app.api.request_api_utils import AUTH_COOKIE
+from app.utils.bitschema_utils import Timezone, OrganizationStatus
+
+
+class OrganizationDAO:
+    
+    """Data Access Object for Users_Extension functionalities"""
+
+    @staticmethod
+    def get_organization(representative_id, representative_name):
+        """Retrieves the organization that is represented by the user which ID is passed as parameter.
+
+        Arguments:
+            representative_id: The ID of the user who represents the organization.
+
+        Returns:
+            The OrganizationModel class represented by the user whose ID was searched.
+        """
+
+        representative_additional_info = UserExtensionModel.find_by_user_id(representative_id)
+        try:
+            if representative_additional_info.is_organization_rep:
+                result = OrganizationModel.find_by_representative(representative_id)
+                try:
+                    return {
+                        "representative_id": result.rep_id,
+                        "representative_name": representative_name,
+                        "representative_department": result.rep_department,
+                        "organization_name":result.name, 
+                        "email": result.email,
+                        "about": result.about,
+                        "address": result.address,
+                        "website": result.website,
+                        "timezone": result.timezone.value,
+                        "phone": result.phone,
+                        "status": result.status.value,
+                        "join_date": result.join_date
+                    }
+                except AttributeError:
+                    return messages.ORGANIZATION_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
+        except AttributeError as e:
+            logging.fatal(f"{e}")
+        return messages.NOT_ORGANIZATION_REPRESENTATIVE, HTTPStatus.FORBIDDEN
+    
+
+    @staticmethod
+    def update_organization(data):
+        """Creates or updates the organization that is represented by the user which ID is passed as parameter.
+
+        Arguments:
+            representative_id: The ID of the user who represents the organization.
+
+        Returns:
+            A dictionary containing "message" which indicates whether or not 
+            the organization was created or updated successfully and "code" for the HTTP response code.
+        """
+
+        try:
+            name = data["name"]
+            email = data["email"]
+            address = data["address"]
+            website = data["website"]
+            timezone_value = data["timezone"]
+            timezone = Timezone(timezone_value).name  
+        except KeyError as e:
+            return e, HTTPStatus.BAD_REQUEST 
+
+        user_json = (AUTH_COOKIE["user"].value)
+        user = ast.literal_eval(user_json)
+        representative_additional_info = UserExtensionModel.find_by_user_id(int(user["id"]))
+        if representative_additional_info.is_organization_rep:
+            organization = OrganizationModel.find_by_representative(int(user["id"]))
+            if not organization:
+                organization = OrganizationModel(int(user["id"]), name, email, address, website, timezone)
+                return update(organization, data, messages.ORGANIZATION_SUCCESSFULLY_CREATED, HTTPStatus.CREATED)  
+            organization.rep_id = int(user["id"])
+            organization.name = name
+            organization.email = email
+            organization.address = address
+            organization.website = website
+            organization.timezone = timezone
+            return update(organization, data, messages.ORGANIZATION_SUCCESSFULLY_UPDATED, HTTPStatus.OK)     
+        return messages.NOT_ORGANIZATION_REPRESENTATIVE, HTTPStatus.FORBIDDEN
+
+def update(organization, data, success_message, status_code):
+    organization.rep_department = data["representative_department"]
+    organization.about = data["about"]
+    organization.phone = data["phone"]
+    status_value = data["status"]
+    organization.status = OrganizationStatus(status_value).name
+    
+    organization.save_to_db()
+
+    return success_message, status_code 
+        
+        
+        

--- a/app/api/dao/personal_background.py
+++ b/app/api/dao/personal_background.py
@@ -1,3 +1,4 @@
+import ast
 from http import HTTPStatus
 from flask import json
 from app.database.models.bit_schema.personal_background import PersonalBackgroundModel
@@ -63,11 +64,6 @@ class PersonalBackgroundDAO:
                 was created or updated successfully and "code" for the HTTP response code.
         """
 
-        try:
-            user_id = int(AUTH_COOKIE["user_id"].value)
-        except ValueError:
-            return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN
-
         others_data = {}
         try:
             others_data["gender_other"] = data["gender_other"]
@@ -80,12 +76,14 @@ class PersonalBackgroundDAO:
             others_data["highest_education_other"] = data["highest_education_other"]
         except KeyError as e:
             return e, HTTPStatus.BAD_REQUEST
-            
-        existing_personal_background = PersonalBackgroundModel.find_by_user_id(user_id)
+        
+        user_json = (AUTH_COOKIE["user"].value)
+        user = ast.literal_eval(user_json)
+        existing_personal_background = PersonalBackgroundModel.find_by_user_id(int(user["id"]))
         if not existing_personal_background:
             try:
                 personal_background = PersonalBackgroundModel(
-                    user_id=user_id,
+                    user_id=int(user["id"]),
                     gender=Gender(data["gender"]).name,
                     age=Age(data["age"]).name,
                     ethnicity=Ethnicity(data["ethnicity"]).name,

--- a/app/api/dao/user_extension.py
+++ b/app/api/dao/user_extension.py
@@ -1,3 +1,4 @@
+import ast
 from http import HTTPStatus
 from flask import json
 from app.database.models.bit_schema.user_extension import UserExtensionModel
@@ -44,17 +45,14 @@ class UserExtensionDAO:
                 the user_exension was updated successfully and "code" for the HTTP response code.
         """
 
-        try:
-            user_id = int(AUTH_COOKIE["user_id"].value)
-        except ValueError:
-            return messages.USER_ID_IS_NOT_RETRIEVED, HTTPStatus.FORBIDDEN    
-
         timezone_value = data["timezone"]
         timezone = Timezone(timezone_value).name   
 
-        user_additional_info = UserExtensionModel.find_by_user_id(user_id)
+        user_json = (AUTH_COOKIE["user"].value)
+        user = ast.literal_eval(user_json)
+        user_additional_info = UserExtensionModel.find_by_user_id(int(user["id"]))
         if not user_additional_info:
-            user_additional_info = UserExtensionModel(user_id, timezone)
+            user_additional_info = UserExtensionModel(int(user["id"]), timezone)
             return update(user_additional_info, data, timezone, messages.ADDITIONAL_INFO_SUCCESSFULLY_CREATED, HTTPStatus.CREATED)    
         return update(user_additional_info, data, timezone, messages.ADDITIONAL_INFO_SUCCESSFULLY_UPDATED, HTTPStatus.OK)     
     

--- a/app/api/models/organization.py
+++ b/app/api/models/organization.py
@@ -1,0 +1,39 @@
+from flask_restx import fields, Model
+
+
+def add_models_to_namespace(api_namespace):
+    api_namespace.models[update_organization_request_model.name] = update_organization_request_model
+    api_namespace.models[get_organization_response_model.name] = get_organization_response_model
+
+update_organization_request_model = Model(
+    "Creates or updates organization request model",
+    {
+        "representative_department": fields.String(required=True, description="Representative department"),
+        "name": fields.String(required=True, description="Organization's name"),
+        "email": fields.String(required=True, description="Organization's email"),
+        "about": fields.String(required=False, description="About the organization"),
+        "address": fields.String(required=False, description="Organization's address"),
+        "website": fields.String(required=True, description="Organization's website"),
+        "timezone": fields.String(required=True, description="Organization's timezone"),
+        "phone": fields.String(required=True, description="Organization's phone"),
+        "status": fields.String(required=True, description="Organization's profile status"),
+    },
+)
+
+get_organization_response_model = Model(
+    "Retrieves organization response model",
+    {
+        "representative_id": fields.Integer(required=True, description="Representative id"),
+        "representative_name": fields.String(required=True, description="Representative name"),
+        "representative_department": fields.String(required=True, description="Representative department"),
+        "organization_name": fields.String(required=True, description="Organization's name"),
+        "email": fields.String(required=True, description="Organization's email"),
+        "about": fields.String(required=False, description="About the organization"),
+        "address": fields.String(required=False, description="Organization's address"),
+        "website": fields.String(required=True, description="Organization's website"),
+        "timezone": fields.String(required=True, description="Organization's timezone"),
+        "phone": fields.String(required=True, description="Organization's phone"),
+        "status": fields.String(required=True, description="Organization's profile status"),
+        "join_date": fields.Float(required=True, description="Organization's join date"),
+    },
+)

--- a/app/api/request_api_utils.py
+++ b/app/api/request_api_utils.py
@@ -37,11 +37,18 @@ def post_request(request_string, data):
             access_expiry_cookie = response_message.get("access_expiry")
             AUTH_COOKIE["Authorization"] = f"Bearer {access_token_cookie}"
             AUTH_COOKIE["Authorization"]["expires"] = access_expiry_cookie
-            AUTH_COOKIE["user_id"] = None
+            result = http_response_checker(get_user(AUTH_COOKIE["Authorization"].value))
+            if result.status_code != 200:
+                response_message = result.message
+                response_code = result.status_code
             response_message = {"access_token": response_message.get("access_token"), "access_expiry": response_message.get("access_expiry")}
-
         logging.fatal(f"{response_message}")
         return response_message, response_code
+
+
+def get_user(token):
+    request_url = "/user" 
+    return get_request(request_url, token, params=None)
 
 
 def get_headers(request_string, params):
@@ -87,7 +94,7 @@ def get_request(request_string, token, params):
             logging.fatal(f"{e}")
         finally:
             if request_string == "/user" and response_code == HTTPStatus.OK:
-                AUTH_COOKIE["user_id"] = response_message.get("id")
+                AUTH_COOKIE["user"] = response_message
             logging.fatal(f"{response_message}")
             return response_message, response_code
     return is_wrong_token

--- a/app/api/resources/organizations.py
+++ b/app/api/resources/organizations.py
@@ -1,0 +1,99 @@
+import ast
+from http import HTTPStatus, cookies
+from flask import request
+from flask_restx import Resource, marshal, Namespace
+from app import messages
+from app.api.request_api_utils import (
+    post_request, 
+    get_request,
+    put_request, 
+    http_response_checker, 
+    AUTH_COOKIE, 
+    validate_token)
+from app.api.resources.common import auth_header_parser
+from app.api.dao.organization import OrganizationDAO
+from app.utils.validation_utils import expected_fields_validator
+from app.api.models.organization import *
+from app.api.validations.organization import validate_update_organization
+
+organizations_ns = Namespace("Organizations", description="Operations related to organizations")
+add_models_to_namespace(organizations_ns)
+
+OrganizationDAO = OrganizationDAO()
+
+
+@organizations_ns.response(
+        HTTPStatus.UNAUTHORIZED,
+        f"{messages.TOKEN_HAS_EXPIRED}\n"
+        f"{messages.TOKEN_IS_INVALID}\n"
+        f"{messages.AUTHORISATION_TOKEN_IS_MISSING}"
+)
+@organizations_ns.response(HTTPStatus.FORBIDDEN, f"{messages.NOT_ORGANIZATION_REPRESENTATIVE}")
+@organizations_ns.response(HTTPStatus.INTERNAL_SERVER_ERROR, f"{messages.INTERNAL_SERVER_ERROR}")
+@organizations_ns.route("organization")
+class Organization(Resource):
+    @classmethod
+    @organizations_ns.doc("get_organization")
+    @organizations_ns.response(HTTPStatus.NOT_FOUND, f"{messages.ORGANIZATION_DOES_NOT_EXIST}")
+    @organizations_ns.response(HTTPStatus.OK, "Successful request", get_organization_response_model)
+    @organizations_ns.expect(auth_header_parser, validate=True)
+    def get(cls):
+        """
+        Returns organization where the current user is the representative.
+
+        A user with valid access token can use this endpoint to view the organization
+        that they represent. The endpoint doesn't take any other input. 
+        """
+        token = request.headers.environ["HTTP_AUTHORIZATION"]
+
+        is_wrong_token = validate_token(token)
+
+        if not is_wrong_token:
+            try:
+                user_json = (AUTH_COOKIE["user"].value)
+                user = ast.literal_eval(user_json)
+                representative_name = user["name"]
+                return OrganizationDAO.get_organization(int(user["id"]), representative_name)
+            except ValueError as e:
+                return e, HTTPStatus.BAD_REQUEST
+        return is_wrong_token
+
+    
+    @classmethod
+    @organizations_ns.doc("update_organization")
+    @organizations_ns.response(HTTPStatus.OK, "Successful request", update_organization_request_model)
+    @organizations_ns.expect(auth_header_parser, update_organization_request_model, validate=True)
+    def put(cls):
+        """
+        Creates or updates organization where the current user is the representative.
+
+        A user with valid access token can use this endpoint to create or update the organization
+        that they represent. The endpoint takes any of the given parameters (representative_department, 
+        organization name, email, about, address, website, timezone (with value as per 
+        Timezone Enum Value), phone, status (with value as per OrganizationStatus Enum Value) and join date). 
+        The response contains a success or error message. 
+        """
+        token = request.headers.environ["HTTP_AUTHORIZATION"]
+
+        is_wrong_token = validate_token(token)
+
+        if not is_wrong_token:
+            data = request.json
+            if not data:
+                return messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT, HTTPStatus.BAD_REQUEST
+
+            is_field_valid = expected_fields_validator(data, update_organization_request_model)
+            if not is_field_valid.get("is_field_valid"):
+                return is_field_valid.get("message"), HTTPStatus.BAD_REQUEST
+            
+            is_not_valid = validate_update_organization(data)
+            if is_not_valid:
+                return is_not_valid, HTTPStatus.BAD_REQUEST
+
+            return OrganizationDAO.update_organization(data)
+              
+        return is_wrong_token
+
+    
+
+

--- a/app/api/validations/organization.py
+++ b/app/api/validations/organization.py
@@ -1,0 +1,32 @@
+from app import messages
+from app.utils.bitschema_utils import *
+from app.utils.validation_utils import is_email_valid, is_phone_valid
+    
+
+def validate_update_organization(data):
+    try:
+        email = data["email"]
+        phone = data["phone"]
+        if not is_email_valid(email):
+            return messages.EMAIL_INPUT_BY_USER_IS_INVALID
+        if not is_phone_valid(phone):
+            return messages.PHONE_OR_MOBILE_IS_NOT_IN_NUMBER_FORMAT
+    except ValueError as e:
+        return e
+    try:
+        timezone_value = data["timezone"]
+        timezone = Timezone(timezone_value).name
+    except ValueError:
+        return messages.TIMEZONE_INPUT_IS_INVALID
+    except KeyError:
+        return messages.TIMEZONE_FIELD_IS_MISSING
+    try:
+        status_value = data["status"]
+        status = OrganizationStatus(status_value).name
+    except ValueError:
+        return messages.STATUS_INPUT_IS_INVALID
+    except KeyError:
+        return messages.ORGANIZATION_STATUS_FIELD_IS_MISSING
+    
+    
+     

--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -280,4 +280,4 @@ def validate_update_personal_background_info_request(data):
         approved.append(YearsOfExperience(data["years_of_experience"]).name)
     except ValueError:
         return messages.PERSONAL_BACKGROUND_IS_INVALID
-    
+

--- a/app/messages.py
+++ b/app/messages.py
@@ -15,7 +15,7 @@ PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH = {
     "message": f"The password field has to be at least {PASSWORD_MIN_LENGTH} characters and no more than {PASSWORD_MAX_LENGTH} characters."
 }
 PHONE_OR_MOBILE_IS_NOT_IN_NUMBER_FORMAT = {
-    "message": "Phone and mobile fields must be in number format. It must contain numbers and may contain dash ""-"" or space "" "" characters."
+    "message": "Phone or mobile fields must be in number format. It must contain numbers and may contain dash ""-"" or space characters."
 }
 WEBSITE_URL_IS_INVALID = {
     "message": "The website url is not in valid format. It must have ""http*"
@@ -25,6 +25,9 @@ TIMEZONE_INPUT_IS_INVALID = {
 }
 PERSONAL_BACKGROUND_IS_INVALID = {
     "messages": "One or more of the personal background fields input provided is/are not within the given list."
+}
+STATUS_INPUT_IS_INVALID = {
+    "message": "Status inpust must be either Draft, Publish, or Archived"
 }
 
 # Not found
@@ -43,7 +46,12 @@ TASK_COMMENT_DOES_NOT_EXIST = {"message": "Task comment does not exist."}
 TASK_COMMENT_WITH_GIVEN_TASK_ID_DOES_NOT_EXIST = {
     "message": "Task comment with given task id does not exist."
 }
-
+ORGANIZATION_DOES_NOT_EXIST = {
+    "message": "Organization does not exist."
+}
+ORGANITATION_ENUM_FIELD_IS_INVALID = {
+    "message": "Either Timezone or Status fields are invalid."
+}
 
 # Missing fields
 MENTOR_ID_FIELD_IS_MISSING = {"message": "Mentor ID field is missing."}
@@ -83,6 +91,9 @@ USER_REVOKE_NOT_ADMIN = {
     "message": "You don't have admin status. You can't" " revoke other admin user."
 }
 USER_IS_NOW_AN_ADMIN = {"message": "User is now an Admin."}
+ORGANIZATION_STATUS_FIELD_IS_MISSING = {
+    "messages": "The status information is missing."
+}
 
 # Mentor availability
 MENTOR_NOT_AVAILABLE_TO_MENTOR = {
@@ -92,10 +103,10 @@ MENTOR_ALREADY_IN_A_RELATION = {"message": "Mentor user is already in a relation
 
 # Mentee availability
 MENTEE_NOT_AVAIL_TO_BE_MENTORED = {
-    "message": "Mentee user is not available" " to be mentored."
+    "message": "Mentee user is not available to be mentored."
 }
 MENTEE_ALREADY_IN_A_RELATION = {
-    "message": "Mentee user is already in a" " relationship."
+    "message": "Mentee user is already in a relationship."
 }
 
 # Mismatch of fields
@@ -106,12 +117,12 @@ TASK_COMMENT_WAS_NOT_CREATED_BY_YOU = {
     "message": "You have not created the comment and therefore cannot " "modify it."
 }
 TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE = {
-    "message": "You have not created the comment and therefore cannot " "delete it."
+    "message": "You have not created the comment and therefore cannot delete it."
 }
 
 # Update
 NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT = {
-    "message": "No data for updating" "profile was sent."
+    "message": "No data for updating profile was sent."
 }
 ADDITIONAL_INFORMATION_DOES_NOT_EXIST = {
     "message": "No additional information found with your data. Please provide them now."
@@ -314,6 +325,8 @@ LIST_TASK_COMMENTS_WITH_SUCCESS = {
 }
 ADDITIONAL_INFO_SUCCESSFULLY_CREATED = {"message": "User additional info successfully created."}
 PERSONAL_BACKGROUND_SUCCESSFULLY_CREATED = {"message": "User personal background information successfully created."}
+ORGANIZATION_SUCCESSFULLY_CREATED = {"message": "Organization was created successfully."}
+ORGANIZATION_SUCCESSFULLY_UPDATED = {"message": "Organization was updated successfully."}
 
 # confimation
 ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed."}
@@ -333,6 +346,12 @@ INTERNAL_SERVER_ERROR = {
 }
 
 UNEXPECTED_INPUT = {"message": "Unexpected input is detected. Please check your input to make sure only approved fields are to be submitted."}
-USER_ID_IS_NOT_RETRIEVED = {
+USER_ID_IS_NOT_RETRIEVED_WITH_GET_USER = {
     "message": "You must view your personal details first before you can proceed."
+}
+USER_ID_IS_NOT_RETRIEVED_WITH_GET_ORGANIZATION = {
+    "message": "You must send GET /organization request first before you can proceed."
+}
+NOT_ORGANIZATION_REPRESENTATIVE = {
+    "message": "You have not declared that you are representing an organization."
 }

--- a/app/utils/bitschema_utils.py
+++ b/app/utils/bitschema_utils.py
@@ -216,3 +216,4 @@ class Timezone(Enum):
 
     def timezone(self):
         return list(map(str, self))
+

--- a/tests/organizations/test_api_get_organization.py
+++ b/tests/organizations/test_api_get_organization.py
@@ -1,0 +1,158 @@
+import unittest
+from http import HTTPStatus, cookies
+from unittest.mock import patch, Mock
+import requests
+from requests.exceptions import HTTPError
+from flask import json
+from flask_restx import marshal
+from app import messages
+from app.database.sqlalchemy_extension import db
+from tests.base_test_case import BaseTestCase
+from app.api.request_api_utils import post_request, get_request, BASE_MS_API_URL, AUTH_COOKIE
+from app.api.models.user import full_user_api_model
+from app.api.models.organization import get_organization_response_model, update_organization_request_model
+from tests.test_data import user1
+from app.database.models.ms_schema.user import UserModel
+from app.database.models.bit_schema.user_extension import UserExtensionModel
+from app.database.models.bit_schema.organization import OrganizationModel
+
+
+class TestGetOrganizationApi(BaseTestCase):
+    @patch("requests.get")
+    @patch("requests.post")
+    def setUp(self, mock_login, mock_get_user):
+        super(TestGetOrganizationApi, self).setUp()
+        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
+        # This date need to be adjusted accordingly once the development is near/pass the stated date
+        # to make sure the test still pass.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        expected_user = marshal(user1, full_user_api_model)
+        
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_user
+        mock_get_response.status_code = success_code
+
+        mock_get_user.return_value = mock_get_response
+        mock_get_user.raise_for_status = json.dumps(success_code)
+        
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+
+        test_user1 = UserModel(
+            name=user1["name"],
+            username=user1["username"],
+            password=user1["password"], 
+            email=user1["email"], 
+            terms_and_conditions_checked=user1["terms_and_conditions_checked"]
+        )
+        test_user1.need_mentoring = user1["need_mentoring"]
+        test_user1.available_to_mentor = user1["available_to_mentor"]
+
+        test_user1.save_to_db()
+        self.test_user1_data = UserModel.find_by_email(test_user1.email)
+        AUTH_COOKIE["user"] = marshal(self.test_user1_data, full_user_api_model)
+        
+
+    def test_api_dao_get_organization_successfully(self):
+        organization = OrganizationModel(
+            rep_id=self.test_user1_data.id, 
+            name="Company ABC",
+            email="companyabc@mail.com",
+            address="506 Elizabeth St, Melbourne VIC 3000, Australia",
+            website="https://www.ames.net.au",
+            timezone="ALASKA_STANDARD_TIME",
+        )
+        organization.rep_department = "H&R Department"
+        organization.about = "This is about ABC"
+        organization.phone = "321-456-789"
+        organization.status = "DRAFT"
+        organization.join_date = 1601478236
+        
+        db.session.add(organization)
+        db.session.commit()
+        
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = True
+        test_user_extension.save_to_db()
+
+        response_organization = {
+            "representative_id": self.test_user1_data.id,
+            "representative_name": self.test_user1_data.name,
+            "representative_department": "H&R Department",
+            "organization_name": "Company ABC",
+            "email": "companyabc@mail.com",
+            "about": "This is about ABC",
+            "address": "506 Elizabeth St, Melbourne VIC 3000, Australia",
+            "website": "https://www.ames.net.au",
+            "timezone": "UTC-09:00/Alaska Standard Time",
+            "phone": "321-456-789",
+            "status": "Draft",
+            "join_date": 1601478236
+        }
+        success_code = HTTPStatus.OK
+        
+        response = self.client.get(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(response.json, response_organization)
+        self.assertEqual(response.status_code, success_code)
+        
+
+    def test_api_dao_get_organization_not_exist(self):
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = True
+        test_user_extension.save_to_db()
+        
+        response = self.client.get(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.NOT_FOUND, response.status_code)
+        self.assertEqual(messages.ORGANIZATION_DOES_NOT_EXIST, response.json)
+
+    
+    def test_api_dao_get_organization_not_representative(self):
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = False
+        test_user_extension.save_to_db()
+
+        response = self.client.get(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
+        self.assertEqual(messages.NOT_ORGANIZATION_REPRESENTATIVE, response.json)

--- a/tests/organizations/test_api_update_organization.py
+++ b/tests/organizations/test_api_update_organization.py
@@ -1,0 +1,174 @@
+import unittest
+from http import HTTPStatus, cookies
+from unittest.mock import patch, Mock
+import requests
+from requests.exceptions import HTTPError
+from flask import json
+from flask_restx import marshal
+from app import messages
+from app.database.sqlalchemy_extension import db
+from app.api.models.user import full_user_api_model
+from tests.base_test_case import BaseTestCase
+from app.api.request_api_utils import post_request, get_request, BASE_MS_API_URL, AUTH_COOKIE
+from app.api.models.organization import get_organization_response_model, update_organization_request_model
+from tests.test_data import user1
+from app.database.models.ms_schema.user import UserModel
+from app.database.models.bit_schema.user_extension import UserExtensionModel
+from app.database.models.bit_schema.organization import OrganizationModel
+
+
+class TestUpdateOrganizationApi(BaseTestCase):
+    @patch("requests.get")
+    @patch("requests.post")
+    def setUp(self, mock_login, mock_get_user):
+        super(TestUpdateOrganizationApi, self).setUp()
+        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
+        # This date need to be adjusted accordingly once the development is near/pass the stated date
+        # to make sure the test still pass.
+        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        success_code = HTTPStatus.OK
+
+        mock_login_response = Mock()
+        mock_login_response.json.return_value = success_message
+        mock_login_response.status_code = success_code
+        mock_login.return_value = mock_login_response
+        mock_login.raise_for_status = json.dumps(success_code)
+
+        expected_user = marshal(user1, full_user_api_model)
+        
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_user
+        mock_get_response.status_code = success_code
+
+        mock_get_user.return_value = mock_get_response
+        mock_get_user.raise_for_status = json.dumps(success_code)
+        
+        user_login_success = {
+            "username": user1.get("username"),
+            "password": user1.get("password")
+        }
+        
+        with self.client:
+            login_response = self.client.post(
+                "/login",
+                data=json.dumps(user_login_success),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+
+        test_user1 = UserModel(
+            name=user1["name"],
+            username=user1["username"],
+            password=user1["password"], 
+            email=user1["email"], 
+            terms_and_conditions_checked=user1["terms_and_conditions_checked"]
+        )
+        test_user1.need_mentoring = user1["need_mentoring"]
+        test_user1.available_to_mentor = user1["available_to_mentor"]
+
+        test_user1.save_to_db()
+        self.test_user1_data = UserModel.find_by_email(test_user1.email)
+        AUTH_COOKIE["user"] = marshal(self.test_user1_data, full_user_api_model)
+
+        self.correct_payload_organization = {
+            "representative_department": "H&R Department",
+            "name": "Company ABC",
+            "email": "companyabc@mail.com",
+            "about": "This is about ABC",
+            "address": "506 Elizabeth St, Melbourne VIC 3000, Australia",
+            "website": "https://www.ames.net.au",
+            "timezone": "UTC-09:00/Alaska Standard Time",
+            "phone": "321-456-789",
+            "status": "Draft",
+        }
+
+        
+    def test_api_dao_create_organization_successfully(self):
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = True
+        test_user_extension.save_to_db()
+
+        response = self.client.put(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            data=json.dumps(
+                    dict(self.correct_payload_organization)
+                ),
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.CREATED, response.status_code)
+        self.assertEqual(messages.ORGANIZATION_SUCCESSFULLY_CREATED, json.loads(response.data))
+
+    def test_api_dao_update_organization_successfully(self):
+        # prepare existing organization
+        organization = OrganizationModel(
+            rep_id=self.test_user1_data.id, 
+            name="Company ABC",
+            email="companyabc@mail.com",
+            address="506 Elizabeth St, Melbourne VIC 3000, Australia",
+            website="https://www.ames.net.au",
+            timezone="ALASKA_STANDARD_TIME",
+        )
+        organization.rep_department = "H&R Department"
+        organization.about = "This is about ABC"
+        organization.phone = "321-456-789"
+        organization.status = "DRAFT"
+        organization.join_date = 1601478236
+        
+        db.session.add(organization)
+        db.session.commit()
+        
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = True
+        test_user_extension.save_to_db()
+
+        update_payload_organization = {
+            "representative_department": "H&R Department",
+            "name": "Company ABC",
+            "email": "companyabc@mail.com",
+            "about": "This is about ABC",
+            "address": "Some Address",
+            "website": "https://www.ames.net.au",
+            "timezone": "UTC-09:00/Alaska Standard Time",
+            "phone": "321-456-789",
+            "status": "Publish",
+        }
+
+        response = self.client.put(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            data=json.dumps(
+                    dict(update_payload_organization)
+                ),
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        self.assertEqual(messages.ORGANIZATION_SUCCESSFULLY_UPDATED, response.json)
+
+    def test_api_dao_get_organization_not_representative(self):
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="ALASKA_STANDARD_TIME"
+        )
+        test_user_extension.is_organization_rep = False
+        test_user_extension.save_to_db()
+
+        response = self.client.put(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            data=json.dumps(
+                    dict(self.correct_payload_organization)
+                ),
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
+        self.assertEqual(messages.NOT_ORGANIZATION_REPRESENTATIVE, response.json)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -39,6 +39,8 @@ user2 = {
     "username": "user2",
     "password": "user2_pwd",
     "terms_and_conditions_checked": True,
+    "available_to_mentor": False,
+    "need_mentoring": True,
 }
 
 user3 = {
@@ -47,6 +49,8 @@ user3 = {
     "username": "user3",
     "password": "user3_pwd",
     "terms_and_conditions_checked": True,
+    "available_to_mentor": True,
+    "need_mentoring": False,
 }
 
 user4 = {

--- a/tests/users/test_api_get_users_personal_details.py
+++ b/tests/users/test_api_get_users_personal_details.py
@@ -17,7 +17,9 @@ from app.api.models.user import public_user_personal_details_response_model
 class TestGetUsersListPersonalDetailsApi(BaseTestCase):
     @patch("requests.get")
     @patch("requests.post")
-    def test_api_list_users_personal_details_with_correct_token(self, mock_login, mock_get_users):
+    def setUp(self, mock_login, mock_get_user):
+        super(TestGetUsersListPersonalDetailsApi, self).setUp()
+        
         # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
         # This date need to be adjusted accordingly once the development is near/pass the stated date
         # to make sure the test still pass.
@@ -30,6 +32,15 @@ class TestGetUsersListPersonalDetailsApi(BaseTestCase):
         mock_login.return_value = mock_login_response
         mock_login.raise_for_status = json.dumps(success_code)
 
+        expected_user = marshal(user1, full_user_api_model)
+        
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_user
+        mock_get_response.status_code = success_code
+
+        mock_get_user.return_value = mock_get_response
+        mock_get_user.raise_for_status = json.dumps(success_code)
+        
         user_login_success = {
             "username": user1.get("username"),
             "password": user1.get("password")
@@ -42,10 +53,55 @@ class TestGetUsersListPersonalDetailsApi(BaseTestCase):
                 follow_redirects=True,
                 content_type="application/json",
             )
-      
+
+        test_user1 = UserModel(
+            name=user1["name"],
+            username=user1["username"],
+            password=user1["password"], 
+            email=user1["email"], 
+            terms_and_conditions_checked=user1["terms_and_conditions_checked"]
+        )
+        test_user1.need_mentoring = user1["need_mentoring"]
+        test_user1.available_to_mentor = user1["available_to_mentor"]
+
+        test_user1.save_to_db()
+        test_user1_data = UserModel.find_by_email(test_user1.email)
+        AUTH_COOKIE["user"] = marshal(test_user1_data, full_user_api_model)
+        
+        
+    @patch("requests.get")
+    def test_api_list_users_personal_details_with_correct_token(self, mock_get_users):
+        test_user2 = UserModel(
+            name=user2["name"],
+            username=user2["username"],
+            password=user2["password"], 
+            email=user2["email"], 
+            terms_and_conditions_checked=user2["terms_and_conditions_checked"]
+        )
+        test_user2.need_mentoring = user2["need_mentoring"]
+        test_user2.available_to_mentor = user2["available_to_mentor"]
+        test_user2.is_email_verified = True
+
+        test_user3 = UserModel(
+            name=user3["name"],
+            username=user3["username"],
+            password=user3["password"], 
+            email=user3["email"], 
+            terms_and_conditions_checked=user3["terms_and_conditions_checked"]
+        )
+        test_user3.need_mentoring = user3["need_mentoring"]
+        test_user3.available_to_mentor = user3["available_to_mentor"]
+        test_user3.is_email_verified = True
+        
+        test_user2.save_to_db()
+        test_user3.save_to_db()
+        
+        test_user2_data = UserModel.find_by_email(test_user2.email)
+        test_user3_data = UserModel.find_by_email(test_user3.email)
+
         expected_list = [
-            marshal(user2, public_user_personal_details_response_model),
-            marshal(user3, public_user_personal_details_response_model)
+            marshal(test_user2_data, public_user_personal_details_response_model),
+            marshal(test_user3_data, public_user_personal_details_response_model)
         ]
         success_code = HTTPStatus.OK
 
@@ -75,32 +131,7 @@ class TestGetUsersListPersonalDetailsApi(BaseTestCase):
 
     
     @patch("requests.get")
-    @patch("requests.post")
-    def test_api_list_users_personal_details_with_token_expired(self, mock_login, mock_get_users):
-        # The access_expiry on this test is set to Friday, 26-Jun-20 04:03:58 UTC.
-        # to make sure the test pass for expired token.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1593144238}
-        success_code = HTTPStatus.OK
-
-        mock_login_response = Mock()
-        mock_login_response.json.return_value = success_message
-        mock_login_response.status_code = success_code
-        mock_login.return_value = mock_login_response
-        mock_login.raise_for_status = json.dumps(success_code)
-
-        user_login_success = {
-            "username": user1.get("username"),
-            "password": user1.get("password")
-        }
-        
-        with self.client:
-            login_response = self.client.post(
-                "/login",
-                data=json.dumps(user_login_success),
-                follow_redirects=True,
-                content_type="application/json",
-            )
-      
+    def test_api_list_users_personal_details_with_token_expired(self, mock_get_users):
         error_message = messages.TOKEN_HAS_EXPIRED
         error_code = HTTPStatus.UNAUTHORIZED
 
@@ -126,6 +157,6 @@ class TestGetUsersListPersonalDetailsApi(BaseTestCase):
                 follow_redirects=True,
             )
         
-        mock_get_users.assert_not_called()
+        mock_get_users.assert_called()
         self.assertEqual(get_response.json, error_message)
         self.assertEqual(get_response.status_code, error_code)

--- a/tests/users/test_api_update_personal_background.py
+++ b/tests/users/test_api_update_personal_background.py
@@ -16,8 +16,9 @@ from app.database.models.bit_schema.personal_background import PersonalBackgroun
 
 class TestUpdatePersonalBackgroundApi(BaseTestCase):
     
+    @patch("requests.get")
     @patch("requests.post")
-    def setUp(self, mock_login):
+    def setUp(self, mock_login, mock_get_user):
         super(TestUpdatePersonalBackgroundApi, self).setUp()
 
         success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
@@ -29,6 +30,15 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
         mock_login.return_value = mock_login_response
         mock_login.raise_for_status = json.dumps(success_code)
 
+        expected_user = marshal(user1, full_user_api_model)
+        
+        mock_get_response = Mock()
+        mock_get_response.json.return_value = expected_user
+        mock_get_response.status_code = success_code
+
+        mock_get_user.return_value = mock_get_response
+        mock_get_user.raise_for_status = json.dumps(success_code)
+        
         user_login_success = {
             "username": user1.get("username"),
             "password": user1.get("password")
@@ -56,7 +66,7 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
 
         self.test_user_data = UserModel.find_by_email(test_user.email)
 
-        AUTH_COOKIE["user_id"] = self.test_user_data.id
+        AUTH_COOKIE["user"] = marshal(self.test_user_data, full_user_api_model)
         
         self.correct_payload_personal_background = {
             "gender": "Female",
@@ -81,17 +91,9 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
         }
         
         
-    @patch("requests.put")
-    def test_api_dao_update_user_personal_background_successfully(self, mock_update_personal_background):
+    def test_api_dao_update_user_personal_background_successfully(self):
         success_message = messages.PERSONAL_BACKGROUND_SUCCESSFULLY_UPDATED
         success_code = HTTPStatus.OK
-
-        mock_get_response = Mock()
-        mock_get_response.json.return_value = success_message
-        mock_get_response.status_code = success_code
-
-        mock_update_personal_background.return_value = mock_get_response
-        mock_update_personal_background.raise_for_status = json.dumps(success_code)
 
         # prepare existing personal background
         others = {
@@ -106,7 +108,7 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
         }
 
         existing_personal_background = PersonalBackgroundModel(
-            user_id=int(AUTH_COOKIE["user_id"].value), 
+            user_id=self.test_user_data.id, 
             gender="DECLINED",
             age="DECLINED",
             ethnicity="DECLINED",
@@ -135,7 +137,7 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
             )
 
         test_user_personal_background_data = PersonalBackgroundModel.query.filter_by(user_id=self.test_user_data.id).first()
-        self.assertEqual(str(test_user_personal_background_data.user_id), AUTH_COOKIE["user_id"].value)
+        self.assertEqual(test_user_personal_background_data.user_id, self.test_user_data.id)
         self.assertEqual(test_user_personal_background_data.gender.value, self.correct_payload_personal_background["gender"])
         self.assertEqual(test_user_personal_background_data.age.value, self.correct_payload_personal_background["age"])
         self.assertEqual(test_user_personal_background_data.ethnicity.value, self.correct_payload_personal_background["ethnicity"])
@@ -159,20 +161,9 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
         self.assertEqual(response.status_code, success_code)
 
     
-    @patch("requests.put")
-    def test_api_dao_update_user_personal_background_invalid_payload(self, mock_update_personal_background):
+    def test_api_dao_update_user_personal_background_invalid_payload(self):
         error_message = messages.PERSONAL_BACKGROUND_IS_INVALID
         error_code = HTTPStatus.BAD_REQUEST
-
-        mock_response = Mock()
-        http_error = requests.exceptions.HTTPError()
-        mock_response.raise_for_status.side_effect = http_error
-        mock_update_personal_background.return_value = mock_response
-
-        mock_error = Mock()
-        mock_error.json.return_value = error_message
-        mock_error.status_code = error_code
-        mock_update_personal_background.side_effect = requests.exceptions.HTTPError(response=mock_error)
 
         test_user_personal_background = {
             "gender": "Some random value",


### PR DESCRIPTION
### Description
Create PUT and GET /organization API endpoints

Fixes #105 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
* Run and test the application manually:
- Login as user who already has additional_info in the database and `is_organization_rep` is True
- try to send PUT /organization request before setting Cookie `user_id` through GET /organization. see error 403 Forbidden and error message
<img width="1397" alt="Screen Shot 2020-08-11 at 9 02 35 pm" src="https://user-images.githubusercontent.com/29667122/89976213-2666a180-dcab-11ea-99e7-0718c46b1b79.png">

- send GET /organization request. Since this user has not created an organization, see error 404 Not Found and message `Organization does not exist`.
<img width="843" alt="Screen Shot 2020-08-11 at 1 08 11 am" src="https://user-images.githubusercontent.com/29667122/89976026-b22bfe00-dcaa-11ea-8056-cc079bf5ca36.png">

- now create organization by sending PUT /organization request with correct payload. see code 201 Created and success message
<img width="1402" alt="Screen Shot 2020-08-11 at 9 30 29 pm" src="https://user-images.githubusercontent.com/29667122/89976257-46966080-dcab-11ea-95fc-6fc4bd4da686.png">

- now try to update the organization by changing some details. On correct update, see code 200 and success message
<img width="1407" alt="Screen Shot 2020-08-11 at 9 34 01 pm" src="https://user-images.githubusercontent.com/29667122/89976310-70e81e00-dcab-11ea-91b1-41ed528db0c2.png">

- logout and login as a user that either has additional_info `is_organization_rep` is `False` or has not created an additional_info. 
- send GET /organization request. see error 403 Forbidden and error message user has not declared `is_organization_rep` value
<img width="1393" alt="Screen Shot 2020-08-11 at 1 16 48 am" src="https://user-images.githubusercontent.com/29667122/89976496-e6ec8500-dcab-11ea-9677-f1262b11d97b.png">

- an example of successful GET /organization request will be as below
<img width="1407" alt="Screen Shot 2020-08-12 at 11 38 28 pm" src="https://user-images.githubusercontent.com/29667122/90021988-491da800-dcf5-11ea-82d8-11528ba8b581.png">

* Run unittests and ensure all tests passed


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

**Additional Info**
This is still a work in progress