### PR TITLE
Refactor login to return is organization representative

### DIFF
--- a/app/api/dao/user_extension.py
+++ b/app/api/dao/user_extension.py
@@ -24,14 +24,27 @@ class UserExtensionDAO:
 
         result = UserExtensionModel.find_by_user_id(user_id)
         if result:
-            return {
-                "user_id": result.user_id,
-                "is_organization_rep": result.is_organization_rep,
-                "timezone": result.timezone.value,
-                "phone": result.additional_info["phone"],
-                "mobile": result.additional_info["mobile"],
-                "personal_website": result.additional_info["personal_website"]
-            }
+            try:
+                phone = result.additional_info["phone"]
+                mobile = result.additional_info["mobile"]
+                personal_website = result.additional_info["personal_website"]
+                return {
+                    "user_id": result.user_id,
+                    "is_organization_rep": result.is_organization_rep,
+                    "timezone": result.timezone.value,
+                    "phone": phone,
+                    "mobile": mobile,
+                    "personal_website": personal_website
+                }
+            except TypeError:
+                return {
+                    "user_id": result.user_id,
+                    "is_organization_rep": result.is_organization_rep,
+                    "timezone": result.timezone.value,
+                    "phone": "",
+                    "mobile": "",
+                    "personal_website": ""
+                }
         return
 
     @staticmethod

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -47,6 +47,7 @@ login_response_body_model = Model(
         "access_expiry": fields.Float(
             required=True, description="Access token expiry UNIX timestamp"
         ),
+        "is_organization_representative": fields.Boolean(required=True, description="User organization representative status"), 
     },
 )
 

--- a/app/api/request_api_utils.py
+++ b/app/api/request_api_utils.py
@@ -37,11 +37,12 @@ def post_request(request_string, data):
             access_expiry_cookie = response_message.get("access_expiry")
             AUTH_COOKIE["Authorization"] = f"Bearer {access_token_cookie}"
             AUTH_COOKIE["Authorization"]["expires"] = access_expiry_cookie
-            result = http_response_checker(get_user(AUTH_COOKIE["Authorization"].value))
-            if result.status_code != 200:
-                response_message = result.message
-                response_code = result.status_code
-            response_message = {"access_token": response_message.get("access_token"), "access_expiry": response_message.get("access_expiry")}
+            set_user = http_response_checker(get_user(AUTH_COOKIE["Authorization"].value))
+            if set_user.status_code != 200:
+                response_message = set_user.message
+                response_code = set_user.status_code
+            else:
+                response_message = {"access_token": response_message.get("access_token"), "access_expiry": response_message.get("access_expiry")}
         logging.fatal(f"{response_message}")
         return response_message, response_code
 


### PR DESCRIPTION
### Description
Added `is_organization_representative` status as successfull login response

Fixes #111

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. Login as a user who has additional info on the record with is_organization_representative value is True. On successfull login see response below
<img width="1557" alt="Screen Shot 2020-08-17 at 11 59 08 am" src="https://user-images.githubusercontent.com/29667122/90353583-f1cb5f00-e089-11ea-8da9-d8e3ab376903.png">

2. Login as a user who has additional info on the record with is_organization_representative value is False. On successful login see response below
<img width="1567" alt="Screen Shot 2020-08-17 at 12 00 12 pm" src="https://user-images.githubusercontent.com/29667122/90353732-61d9e500-e08a-11ea-97ac-5df15848cba6.png">

3. Now delete the additional info of the last logged in user from the database (where is_organization_representative is False). on successful login see the same response as `2` response above.

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
