### PR TITLE
Bug: Set user timezone to GMT0 when no Additional Info given

### DIFF
--- a/app/api/dao/organization.py
+++ b/app/api/dao/organization.py
@@ -134,7 +134,11 @@ class OrganizationDAO:
                         try:
                             if member_additional_info.is_organization_rep:
                                 if organization["rep_id"] == user["id"]:
-                                    readable_join_date = convert_timestamp_to_human_date(organization["join_date"], user_additional_info.timezone.value)
+                                    readable_join_date = ""
+                                    try:
+                                        readable_join_date = convert_timestamp_to_human_date(organization["join_date"], user_additional_info.timezone.value)
+                                    except AttributeError:
+                                            readable_join_date = convert_timestamp_to_human_date(organization["join_date"], Timezone.GMT0.value)
                                     organization_item = {
                                         "id": organization["id"],
                                         "representative_id": organization["rep_id"],

--- a/app/api/dao/program.py
+++ b/app/api/dao/program.py
@@ -158,10 +158,14 @@ def get_program(program, organization, user):
         user_json = (AUTH_COOKIE["user"].value)
         user = ast.literal_eval(user_json)
         representative_additional_info = UserExtensionModel.find_by_user_id(int(user["id"]))
-        
-        readable_start_date = convert_timestamp_to_human_date(program.start_date, representative_additional_info.timezone.value)
-        readable_end_date = convert_timestamp_to_human_date(program.end_date, representative_additional_info.timezone.value)
-        readable_creation_date = convert_timestamp_to_human_date(program.creation_date, representative_additional_info.timezone.value)
+        try:
+            readable_start_date = convert_timestamp_to_human_date(program.start_date, representative_additional_info.timezone.value)
+            readable_end_date = convert_timestamp_to_human_date(program.end_date, representative_additional_info.timezone.value)
+            readable_creation_date = convert_timestamp_to_human_date(program.creation_date, representative_additional_info.timezone.value)
+        except AttributeError:
+            readable_start_date = convert_timestamp_to_human_date(program.start_date, Timezone.GMT0.value)
+            readable_end_date = convert_timestamp_to_human_date(program.end_date, Timezone.GMT0.value)
+            readable_creation_date = convert_timestamp_to_human_date(program.creation_date, Timezone.GMT0.value)
 
         return {
             "id":program.id,


### PR DESCRIPTION
### Description
Set user timezone to GMT0 when no additional info is given. This is to prevent GET /organization, GET /organizations/{organization_id}/programs and 
GET /organizations/{organization_id/programs/{program_id} call won't crash.

Fixes #117 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- register a new user, verify email and login
- send GET/organizations. See join_date in GMT0 timezone.
<img width="742" alt="Screen Shot 2020-08-28 at 5 10 33 pm" src="https://user-images.githubusercontent.com/29667122/91532269-67b8ab80-e951-11ea-850c-c5b580c1b8e6.png">

- send GET /organizations/{organization_id}/programs. see date related fields in GMT0 timezone
<img width="761" alt="Screen Shot 2020-08-28 at 5 12 28 pm" src="https://user-images.githubusercontent.com/29667122/91532440-ac444700-e951-11ea-9f9f-ebf187424e46.png">

- send GET /organizations/{organization_id}/programs/{program_id}. see all related date fields in GMT0 timezone.
<img width="758" alt="Screen Shot 2020-08-28 at 5 01 46 pm" src="https://user-images.githubusercontent.com/29667122/91532537-d138ba00-e951-11ea-9632-d2f6cc20eb0b.png">


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules