### PR TITLE
Doc: Replace DB_REMOTE_URI to match setup inctruction

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-FLASK_ENVIRONMENT_CONFIG = <dev-or-test-or-prod>
+FLASK_ENVIRONMENT_CONFIG = <local-dev-or-test-or-prod>
 SECRET_KEY = <your-secret-key>
 SECURITY_PASSWORD_SALT = <your-security-password-salt>
 MAIL_DEFAULT_SENDER = <mail-default-sender>
@@ -11,5 +11,5 @@ DB_TYPE=postgresql
 DB_USERNAME= <db-username>
 DB_PASSWORD= <db-password>
 DB_ENDPOINT= <db-endpoint>
-DB_NAME=bit_schema
-DB_TEST_NAME=bit_schema_test
+DB_NAME= <db-name>
+DB_TEST_NAME= <db-test-name>

--- a/config.py
+++ b/config.py
@@ -90,9 +90,7 @@ class LocalConfig(BaseConfig):
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
     
-    # Using elephantsql - BridgeInTech remote db
-    # https://bridge-in-tech-bit-test.herokuapp.com
-    SQLALCHEMY_DATABASE_URI = os.getenv('DB_REMOTE_URL')
+    SQLALCHEMY_DATABASE_URI = BaseConfig.build_db_uri()
     
 class TestingConfig(BaseConfig):
     TESTING = True


### PR DESCRIPTION
### Description
Remove DB_REMOTE_URI to using BaseConfig and add `local` as part of options on `FLASK_ENVIRONMENT_CONFIG`.

Fixes #124, #123 , #122  

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- confirmed that PR build on Travis passed
<img width="1680" alt="Screen Shot 2020-08-30 at 6 07 01 pm" src="https://user-images.githubusercontent.com/29667122/91654399-a8e4c300-eaeb-11ea-87c8-999564ad469e.png">

- tested runninng the app with `FLASK_ENVIRONMENT_CONFIG` set to dev for both MS (ms-backend-server branch) and BIT servers and give same credentials to  the fields for DB_**. Tried sending all GET requests with successful outcome.
<img width="634" alt="Screen Shot 2020-08-31 at 12 07 32 am" src="https://user-images.githubusercontent.com/29667122/91661249-1e698700-eb1e-11ea-87b6-d741e2fadbf4.png">


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

**Additional Note**
To test this PR please use the latest version of my fork repo [ms-backend-server](https://github.com/mtreacy002/mentorship-backend/tree/ms-backend-server) (commit IDs b2e2676) as the MS backend server. You also need to set the `FLASK_ENVIRONMENT_CONFIG` to `dev` and give your own db credentials on the db params stated in the [backend setup instructions](https://github.com/anitab-org/bridge-in-tech-backend/wiki/BIT-development-environment-setup#7th-create-the-env-file-using-envtemplate). Note that you don't have to create a remote db just for testing this PR, you can use your local postgre. If you are using the local postgres, your db params will look like below:
DB_TYPE = <postgres or postgresql or postgres+psycopg2 or postgresql+psycopg2>
DB_USERNAME = your postgres username>
DB_PASSWORD = <your postgres password, if you don't create a separate db password>
export DB_ENDPOINT= localhost:5432
export DB_NAME = bit_schema