### PR TITLE
Fix: removes postgresql db uri MacOS specific syntax

### DIFF
--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -25,8 +25,6 @@ class TestTestingConfig(TestCase):
         self.assertTrue(application.config["TESTING"])
         self.assertFalse(application.config["SQLALCHEMY_TRACK_MODIFICATIONS"])
         self.assertTrue(application.config["MOCK_EMAIL"])
-        self.assertEqual("postgresql:///bit_schema_test", application.config["SQLALCHEMY_DATABASE_URI"]
-        )
         self.assertIsNotNone(current_app)
 
 
@@ -98,9 +96,6 @@ class TestLocalConfig(TestCase):
         self.assertTrue(application.config["DEBUG"])
         self.assertFalse(application.config["TESTING"])
         self.assertFalse(application.config["SQLALCHEMY_TRACK_MODIFICATIONS"])
-        self.assertEqual(
-            "postgresql:///bit_schema", application.config["SQLALCHEMY_DATABASE_URI"]
-        )
         self.assertIsNotNone(current_app)
 
 


### PR DESCRIPTION
### Description
This PR removes MacOS specific syntax for connection to postgresql as explained in issue #132 

Fixes #132 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on Windows OS on Python test explorer VSCode IDE. All existing tests passed as a result.

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
