### PR TITLE
Fix: Replace token access expiry to self-adjusting date

### DIFF
--- a/tests/organizations/test_api_update_organization.py
+++ b/tests/organizations/test_api_update_organization.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -15,6 +16,7 @@ from tests.test_data import user1
 from app.database.models.ms_schema.user import UserModel
 from app.database.models.bit_schema.user_extension import UserExtensionModel
 from app.database.models.bit_schema.organization import OrganizationModel
+from app.utils.date_converter import convert_timestamp_to_human_date
 
 
 class TestUpdateOrganizationApi(BaseTestCase):
@@ -22,10 +24,9 @@ class TestUpdateOrganizationApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestUpdateOrganizationApi, self).setUp()
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()
@@ -117,8 +118,9 @@ class TestUpdateOrganizationApi(BaseTestCase):
         organization.about = "This is about ABC"
         organization.phone = "321-456-789"
         organization.status = "DRAFT"
-        organization.join_date = 1601478236
-        
+        # joined one month prior to access date
+        organization.join_date = time.time() - 60*60*24*7
+
         db.session.add(organization)
         db.session.commit()
         

--- a/tests/users/test_api_create_personal_background.py
+++ b/tests/users/test_api_create_personal_background.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -20,8 +21,9 @@ class TestCreatePersonalBackgroundApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestCreatePersonalBackgroundApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_create_user_additional_info.py
+++ b/tests/users/test_api_create_user_additional_info.py
@@ -1,4 +1,5 @@
 import ast
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -21,8 +22,9 @@ class TestCreateUserAdditionalInfoApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestCreateUserAdditionalInfoApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_get_other_user_details.py
+++ b/tests/users/test_api_get_other_user_details.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -20,10 +21,9 @@ class TestGetOtherUserPersonalDetailsApi(BaseTestCase):
     def setUp(self, mock_login, mock_get_user):
         super(TestGetOtherUserPersonalDetailsApi, self).setUp()
 
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_get_personal_background.py
+++ b/tests/users/test_api_get_personal_background.py
@@ -1,4 +1,5 @@
 import ast
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -21,8 +22,9 @@ class TestGetUserPersonalBackgroundApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestGetUserPersonalBackgroundApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_get_user_additional_info.py
+++ b/tests/users/test_api_get_user_additional_info.py
@@ -1,4 +1,5 @@
 import ast
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -21,8 +22,9 @@ class TestGetUserAdditionalInfoApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestGetUserAdditionalInfoApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_get_user_details.py
+++ b/tests/users/test_api_get_user_details.py
@@ -1,4 +1,5 @@
 import ast
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -19,10 +20,9 @@ class TestGetUserDetailsApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestGetUserDetailsApi, self).setUp()
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()
@@ -72,42 +72,7 @@ class TestGetUserDetailsApi(BaseTestCase):
 
 
     @patch("requests.get")
-    @patch("requests.post")
-    def test_api_get_user_details_with_incorrect_token(self, mock_login, mock_get_user):
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
-        success_code = HTTPStatus.OK
-
-        mock_login_response = Mock()
-        mock_login_response.json.return_value = success_message
-        mock_login_response.status_code = success_code
-        mock_login.return_value = mock_login_response
-        mock_login.raise_for_status = json.dumps(success_code)
-
-        expected_user = marshal(user1, full_user_api_model)
-        
-        mock_get_response = Mock()
-        mock_get_response.json.return_value = expected_user
-        mock_get_response.status_code = success_code
-
-        mock_get_user.return_value = mock_get_response
-        mock_get_user.raise_for_status = json.dumps(success_code)
-       
-        user_login_success = {
-            "username": user1.get("username"),
-            "password": user1.get("password")
-        }
-        
-        with self.client:
-            login_response = self.client.post(
-                "/login",
-                data=json.dumps(user_login_success),
-                follow_redirects=True,
-                content_type="application/json",
-            )
-      
+    def test_api_get_user_details_with_incorrect_token(self, mock_get_user):
         error_message = messages.TOKEN_IS_INVALID
         error_code = HTTPStatus.UNAUTHORIZED
 

--- a/tests/users/test_api_get_users_personal_details.py
+++ b/tests/users/test_api_get_users_personal_details.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -19,11 +20,9 @@ class TestGetUsersListPersonalDetailsApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestGetUsersListPersonalDetailsApi, self).setUp()
-        
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus
 from unittest.mock import patch, Mock
@@ -37,10 +38,9 @@ class TestUserLoginApi(BaseTestCase):
     @patch("requests.get")
     @patch("requests.post")
     def test_api_login_successful(self, mock_login, mock_get_user):
-        # The access_expiry on this test is set to Wednesday, 30-Sep-20 15:03:56 UTC.
-        # This date need to be adjusted accordingly once the development is near/pass the stated date
-        # to make sure the test still pass.
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_response = Mock()

--- a/tests/users/test_api_update_personal_background.py
+++ b/tests/users/test_api_update_personal_background.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -20,8 +21,9 @@ class TestUpdatePersonalBackgroundApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestUpdatePersonalBackgroundApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_update_user_additional_info.py
+++ b/tests/users/test_api_update_user_additional_info.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -20,8 +21,9 @@ class TestUpdateUserAdditionalInfoApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login, mock_get_user):
         super(TestUpdateUserAdditionalInfoApi, self).setUp()
-
-        success_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
         mock_login_response = Mock()

--- a/tests/users/test_api_update_user_details.py
+++ b/tests/users/test_api_update_user_details.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from http import HTTPStatus, cookies
 from unittest.mock import patch, Mock
@@ -19,8 +20,9 @@ class TestUpdateUserDetailsApi(BaseTestCase):
     @patch("requests.post")
     def setUp(self, mock_login):
         super(TestUpdateUserDetailsApi, self).setUp()
-
-        success_login_message = {"access_token": "this is fake token", "access_expiry": 1601478236}
+        # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
+        access_expiry = time.time() + 60*60*24*28
+        success_login_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_login_code = HTTPStatus.OK
 
         mock_login_response = Mock()


### PR DESCRIPTION
### Description
Replace the token access expiry to future date (Oct 2, 2021) so the tests won't fail.

Fixes #165 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Runniing tests on VSCode IDE Tests explorer and on terminal resulted in all tests passed.
<img width="1680" alt="Screen Shot 2020-10-03 at 10 20 09 am" src="https://user-images.githubusercontent.com/29667122/94979178-b1a23c00-0564-11eb-846c-22530ee4a1a2.png">

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes