### PR TITLE
Bugfix: Add duplicate organization name check

### DIFF
--- a/app/api/dao/organization.py
+++ b/app/api/dao/organization.py
@@ -3,6 +3,8 @@ import ast
 from http import HTTPStatus
 from flask import json
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+
 from app.database.models.bit_schema.organization import OrganizationModel
 from app.database.models.bit_schema.user_extension import UserExtensionModel
 from app import messages
@@ -73,8 +75,14 @@ class OrganizationDAO:
             return messages.NOT_ORGANIZATION_REPRESENTATIVE, HTTPStatus.FORBIDDEN
         except AttributeError:
             return messages.NOT_ORGANIZATION_REPRESENTATIVE, HTTPStatus.FORBIDDEN
+        except IntegrityError as e:
+            if "organizations_name" in e.orig.args[0]:
+                return messages.ORGANIZATION_NAME_ALREADY_USED, HTTPStatus.CONFLICT
+            return messages.INVALID_REQUEST_DATA, HTTPStatus.BAD_REQUEST
+        except Exception:
+            return messages.UNEXPECTED_ERROR, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    
+
     @staticmethod
     def list_organizations(
         name,

--- a/app/database/models/bit_schema/organization.py
+++ b/app/database/models/bit_schema/organization.py
@@ -1,5 +1,7 @@
 import time
 from sqlalchemy import null
+from sqlalchemy.exc import DBAPIError
+
 from app.database.sqlalchemy_extension import db
 from app.utils.bitschema_utils import OrganizationStatus, Timezone
 from app.database.models.bit_schema.program import ProgramModel
@@ -113,8 +115,12 @@ class OrganizationModel(db.Model):
 
     def save_to_db(self) -> None:
         """Adds an organization to the database. """
-        db.session.add(self)
-        db.session.commit()
+        try:
+            db.session.add(self)
+            db.session.commit()
+        except DBAPIError:
+            db.session.rollback()
+            raise
 
     def delete_from_db(self) -> None:
         """Deletes an organization from the database. """

--- a/app/messages.py
+++ b/app/messages.py
@@ -377,3 +377,9 @@ USER_ID_IS_NOT_RETRIEVED_WITH_GET_ORGANIZATION = {
 NOT_ORGANIZATION_REPRESENTATIVE = {
     "message": "You have not declared that you are representing an organization."
 }
+INVALID_REQUEST_DATA = {"message": "Data you provided cannot be processed. Make sure your data is acceptable."}
+UNEXPECTED_ERROR = {"message": "An unexpected error occurred. Please, try again later or contact the administrator."}
+
+# Non-unique value messages
+ORGANIZATION_NAME_ALREADY_USED = {"message": "Organization with that name already exists."}
+

--- a/tests/organizations/test_api_update_organization.py
+++ b/tests/organizations/test_api_update_organization.py
@@ -12,7 +12,7 @@ from app.api.models.user import full_user_api_model
 from tests.base_test_case import BaseTestCase
 from app.api.request_api_utils import post_request, get_request, BASE_MS_API_URL, AUTH_COOKIE
 from app.api.models.organization import get_organization_response_model, update_organization_request_model
-from tests.test_data import user1
+from tests.test_data import user1, user2
 from app.database.models.ms_schema.user import UserModel
 from app.database.models.bit_schema.user_extension import UserExtensionModel
 from app.database.models.bit_schema.organization import OrganizationModel
@@ -25,7 +25,7 @@ class TestUpdateOrganizationApi(BaseTestCase):
     def setUp(self, mock_login, mock_get_user):
         super(TestUpdateOrganizationApi, self).setUp()
         # set access expiry 4 weeks from today's date (sc*min*hrrs*days)
-        access_expiry = time.time() + 60*60*24*28
+        access_expiry = time.time() + 60 * 60 * 24 * 28
         success_message = {"access_token": "this is fake token", "access_expiry": access_expiry}
         success_code = HTTPStatus.OK
 
@@ -36,19 +36,19 @@ class TestUpdateOrganizationApi(BaseTestCase):
         mock_login.raise_for_status = json.dumps(success_code)
 
         expected_user = marshal(user1, full_user_api_model)
-        
+
         mock_get_response = Mock()
         mock_get_response.json.return_value = expected_user
         mock_get_response.status_code = success_code
 
         mock_get_user.return_value = mock_get_response
         mock_get_user.raise_for_status = json.dumps(success_code)
-        
+
         user_login_success = {
             "username": user1.get("username"),
             "password": user1.get("password")
         }
-        
+
         with self.client:
             login_response = self.client.post(
                 "/login",
@@ -56,21 +56,18 @@ class TestUpdateOrganizationApi(BaseTestCase):
                 follow_redirects=True,
                 content_type="application/json",
             )
-
         test_user1 = UserModel(
             name=user1["name"],
             username=user1["username"],
-            password=user1["password"], 
-            email=user1["email"], 
+            password=user1["password"],
+            email=user1["email"],
             terms_and_conditions_checked=user1["terms_and_conditions_checked"]
         )
         test_user1.need_mentoring = user1["need_mentoring"]
         test_user1.available_to_mentor = user1["available_to_mentor"]
-
         test_user1.save_to_db()
         self.test_user1_data = UserModel.find_by_email(test_user1.email)
         AUTH_COOKIE["user"] = marshal(self.test_user1_data, full_user_api_model)
-
         self.correct_payload_organization = {
             "representative_department": "H&R Department",
             "name": "Company ABC",
@@ -83,7 +80,6 @@ class TestUpdateOrganizationApi(BaseTestCase):
             "status": "Draft",
         }
 
-        
     def test_api_dao_create_organization_successfully(self):
         test_user_extension = UserExtensionModel(
             user_id=self.test_user1_data.id,
@@ -91,23 +87,39 @@ class TestUpdateOrganizationApi(BaseTestCase):
         )
         test_user_extension.is_organization_rep = True
         test_user_extension.save_to_db()
-
         response = self.client.put(
             "/organization",
             headers={"Authorization": AUTH_COOKIE["Authorization"].value},
             data=json.dumps(
-                    dict(self.correct_payload_organization)
-                ),
+                dict(self.correct_payload_organization)
+            ),
             follow_redirects=True,
             content_type="application/json",
         )
         self.assertEqual(HTTPStatus.CREATED, response.status_code)
         self.assertEqual(messages.ORGANIZATION_SUCCESSFULLY_CREATED, json.loads(response.data))
 
-    def test_api_dao_update_organization_successfully(self):
-        # prepare existing organization
+    def test_api_dao_create_organization_when_name_not_unique(self):
+        # new user
+        test_user = UserModel(
+            name=user2["name"],
+            username=user2["username"],
+            password=user2["password"],
+            email=user2["email"],
+            terms_and_conditions_checked=user2["terms_and_conditions_checked"]
+        )
+        test_user.need_mentoring = user2["need_mentoring"]
+        test_user.available_to_mentor = user2["available_to_mentor"]
+
+        test_user.save_to_db()
+        test_user_extension = UserExtensionModel(
+            user_id=self.test_user1_data.id,
+            timezone="AUSTRALIA_MELBOURNE"
+        )
+        test_user_extension.is_organization_rep = True
+        test_user_extension.save_to_db()
         organization = OrganizationModel(
-            rep_id=self.test_user1_data.id, 
+            rep_id=test_user.id,
             name="Company ABC",
             email="companyabc@mail.com",
             address="506 Elizabeth St, Melbourne VIC 3000, Australia",
@@ -119,18 +131,48 @@ class TestUpdateOrganizationApi(BaseTestCase):
         organization.phone = "321-456-789"
         organization.status = "DRAFT"
         # joined one month prior to access date
-        organization.join_date = time.time() - 60*60*24*7
+        organization.join_date = time.time() - 60 * 60 * 24 * 7
+        organization.save_to_db()
+
+        # test creating the org with the same name (with another user)
+        response = self.client.put(
+            "/organization",
+            headers={"Authorization": AUTH_COOKIE["Authorization"].value},
+            data=json.dumps(
+                dict(self.correct_payload_organization)
+            ),
+            follow_redirects=True,
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.CONFLICT, response.status_code)
+        self.assertEqual(messages.ORGANIZATION_NAME_ALREADY_USED, json.loads(response.data))
+
+    def test_api_dao_update_organization_successfully(self):
+        # prepare existing organization
+        organization = OrganizationModel(
+            rep_id=self.test_user1_data.id,
+            name="Company ABC",
+            email="companyabc@mail.com",
+            address="506 Elizabeth St, Melbourne VIC 3000, Australia",
+            website="https://www.ames.net.au",
+            timezone="AUSTRALIA_MELBOURNE",
+        )
+        organization.rep_department = "H&R Department"
+        organization.about = "This is about ABC"
+        organization.phone = "321-456-789"
+        organization.status = "DRAFT"
+        # joined one month prior to access date
+        organization.join_date = time.time() - 60 * 60 * 24 * 7
 
         db.session.add(organization)
         db.session.commit()
-        
+
         test_user_extension = UserExtensionModel(
             user_id=self.test_user1_data.id,
             timezone="AUSTRALIA_MELBOURNE"
         )
         test_user_extension.is_organization_rep = True
         test_user_extension.save_to_db()
-
         update_payload_organization = {
             "representative_department": "H&R Department",
             "name": "Company ABC",
@@ -142,13 +184,12 @@ class TestUpdateOrganizationApi(BaseTestCase):
             "phone": "321-456-789",
             "status": "Publish",
         }
-
         response = self.client.put(
             "/organization",
             headers={"Authorization": AUTH_COOKIE["Authorization"].value},
             data=json.dumps(
-                    dict(update_payload_organization)
-                ),
+                dict(update_payload_organization)
+            ),
             follow_redirects=True,
             content_type="application/json",
         )
@@ -162,13 +203,12 @@ class TestUpdateOrganizationApi(BaseTestCase):
         )
         test_user_extension.is_organization_rep = False
         test_user_extension.save_to_db()
-
         response = self.client.put(
             "/organization",
             headers={"Authorization": AUTH_COOKIE["Authorization"].value},
             data=json.dumps(
-                    dict(self.correct_payload_organization)
-                ),
+                dict(self.correct_payload_organization)
+            ),
             follow_redirects=True,
             content_type="application/json",
         )


### PR DESCRIPTION
### Description

Added handling of the situation when the user tries to create the new organization with the name of some other persisted organization. Fixes #110.

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Tested through Swagger UI:
![image](https://user-images.githubusercontent.com/16724101/110331320-40891800-801f-11eb-86ec-2caa7abfab34.png)
2. Added unit test to cover this scenario

### Checklist:
<!--**Delete irrelevant options.**-->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
