### PR TITLE
chore: Add BIT web remote github.io to CORS origins

### DIFF
--- a/run.py
+++ b/run.py
@@ -37,7 +37,12 @@ def create_app(config_filename: str) -> Flask:
 
     migrate = Migrate(app, db)
 
-    cors.init_app(app, resources={r"*": {"origins": "http://localhost:3000"}})
+    cors.init_app(
+        app,
+        resources={
+            r"*": {"origins": {"http://localhost:3000", "https://anitab-org.github.io"}}
+        },
+    )
 
     from app.api.jwt_extension import jwt
 


### PR DESCRIPTION
### Description
Add https://anitab-org.github.io/bridge-in-tech-web/ to CORS origin so that user can use remote BIT web as frontend application with local BIT backend running.

Fixes #271 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Steps:
1. Run BIT and MS backends on local machine
2. go to https://anitab-org.github.io/bridge-in-tech-web
3. See Homepage with Main Navbar showing default (indicated by `Sign In` and `Sign Up` on the right)
4. login as existing user
5. See Homepage with the logged-in Main navbar (indicated by `Sign Out` tab on the right) and the Sidebar for members navigation.
![ezgif com-gif-maker (68)](https://user-images.githubusercontent.com/29667122/123513673-a8986280-d6d1-11eb-956e-6aaca471ac67.gif)


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes